### PR TITLE
APPDESCRIP-4 Implement application generator plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+ij_continuation_indent_size = 2
+indent_style = space
+max_line_length = 120
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+# use always lf end of lines for bash scripts
+*.sh text eol=lf

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @folio-org/eureka

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Purpose
+
+<!--
+  Why are you making this change? There is nothing more important
+  to provide to the reviewer and to future readers than the cause
+  that gave rise to this pull request. Be careful to avoid circular
+  statements like "the purpose is to update the schema." and
+  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
+  which is currently missing in the schema"
+
+  The purpose may seem self-evident to you now, but the standard to
+  hold yourself to should be "can a developer parachuting into this
+  project reconstruct the necessary context merely by reading this
+  section."
+ -->
+
+## Approach
+
+<!--
+ How does this change fulfill the purpose? It's best to talk
+ high-level strategy and avoid code-splaining the commit history.
+
+ The goal is not only to explain what you did, but help other
+ developers *work* with your solution in the future.
+-->
+
+## TODOS and Open Questions
+
+<!-- OPTIONAL
+- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
+-->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      dev-deps:
+        dependency-type: "development"
+      prod-deps:
+        dependency-type: "production"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+src/main/resources/*-dev.*
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### OS ###
+.DS_Store
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # folio-application-generator
-A Maven plugin to generate application descriptor from a template
+
+Copyright (C) 2022-2024 The Open Library Foundation
+
+This software is distributed under the terms of the Apache License,
+Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
+

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+lombok.addLombokGeneratedAnnotation = true
+lombok.anyconstructor.addconstructorproperties = true

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,347 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.folio</groupId>
+  <artifactId>folio-application-generator</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>maven-plugin</packaging>
+  <name>folio-application-generator</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven-plugin-tools.version>3.11.0</maven-plugin-tools.version>
+    <maven-plugin-api.version>3.9.6</maven-plugin-api.version>
+    <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+    <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
+
+    <semver4j.version>5.2.2</semver4j.version>
+    <lombok.version>1.18.30</lombok.version>
+    <maven-core.version>3.9.6</maven-core.version>
+    <commons-text.version>1.11.0</commons-text.version>
+    <commons-collections4.version>4.4</commons-collections4.version>
+
+    <folio-java-checkstyle.version>1.0.1</folio-java-checkstyle.version>
+    <maven-checkstyle.version>10.13.0</maven-checkstyle.version>
+
+    <assertj-core.version>3.25.3</assertj-core.version>
+    <jackson-databind.version>2.16.1</jackson-databind.version>
+    <junit-jupiter.version>5.10.2</junit-jupiter.version>
+    <mockito-junit-jupiter.version>5.11.0</mockito-junit-jupiter.version>
+    <spring-context.version>6.1.4</spring-context.version>
+    <aws-sdk.version>2.25.3</aws-sdk.version>
+    <testcontainers.version>1.19.7</testcontainers.version>
+    <slf4j.version>2.0.12</slf4j.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>${maven-plugin-api.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>${maven-plugin-tools.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>${lombok.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven-core.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.semver4j</groupId>
+      <artifactId>semver4j</artifactId>
+      <version>${semver4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>${spring-context.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson-databind.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>${commons-text.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+      <version>${aws-sdk.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>apache-client</artifactId>
+      <version>${aws-sdk.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj-core.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>${mockito-junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>auto-clean</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <goalPrefix>${project.name}</goalPrefix>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <configuration>
+          <preparationGoals>clean verify</preparationGoals>
+          <tagNameFormat>v@{project.version}</tagNameFormat>
+          <pushChanges>false</pushChanges>
+          <localCheckout>true</localCheckout>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+          <groups>unit</groups>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>${maven-checkstyle.version}</version>
+          </dependency>
+
+          <dependency>
+            <groupId>org.folio</groupId>
+            <artifactId>folio-java-checkstyle</artifactId>
+            <version>${folio-java-checkstyle.version}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>verify-style</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <sourceDirectories>
+            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+            <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+          </sourceDirectories>
+          <failsOnError>true</failsOnError>
+          <outputEncoding>UTF-8</outputEncoding>
+          <inputEncoding>UTF-8</inputEncoding>
+          <violationSeverity>warning</violationSeverity>
+          <failOnViolation>true</failOnViolation>
+          <logViolationsToConsole>true</logViolationsToConsole>
+          <configLocation>folio-checkstyle/checkstyle.xml</configLocation>
+          <cacheFile>${basedir}/target/cachefile</cacheFile>
+        </configuration>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <repositories>
+    <repository>
+      <id>folio-nexus</id>
+      <name>FOLIO Maven repository</name>
+      <url>https://repository.folio.org/repository/maven-folio</url>
+    </repository>
+
+    <repository>
+      <id>index-data-nexus</id>
+      <name>FOLIO Maven repository</name>
+      <url>https://maven.indexdata.com</url>
+    </repository>
+  </repositories>
+
+  <distributionManagement>
+    <repository>
+      <id>folio-nexus</id>
+      <name>FOLIO Release Repository</name>
+      <url>https://repository.folio.org/repository/maven-releases/</url>
+      <uniqueVersion>false</uniqueVersion>
+      <layout>default</layout>
+    </repository>
+    <snapshotRepository>
+      <id>folio-nexus</id>
+      <name>FOLIO Snapshot Repository</name>
+      <uniqueVersion>true</uniqueVersion>
+      <url>https://repository.folio.org/repository/maven-snapshots/</url>
+      <layout>default</layout>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>folio-nexus</id>
+      <name>FOLIO Maven repository</name>
+      <url>https://repository.folio.org/repository/maven-folio</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <scm>
+    <url>https://https://github.com/folio-org/mgr-tenant-entitlements</url>
+    <connection>scm:git:git://github.com:folio-org/mgr-tenant-entitlements.git</connection>
+    <developerConnection>scm:git:git@github.com:folio-org/mgr-tenant-entitlements.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+</project>

--- a/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
+++ b/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
@@ -1,0 +1,69 @@
+package org.folio.app.generator;
+
+import static java.lang.Boolean.parseBoolean;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.util.List;
+import javax.inject.Inject;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.folio.app.generator.configuration.ApplicationContextBuilder;
+import org.folio.app.generator.model.registry.ConfigModuleRegistry;
+import org.folio.app.generator.service.ModuleRegistryProvider;
+import org.folio.app.generator.utils.PluginConfig;
+import org.springframework.context.support.GenericApplicationContext;
+import software.amazon.awssdk.regions.Region;
+
+public abstract class AbstractGeneratorMojo extends AbstractMojo {
+
+  @Parameter(defaultValue = "${project}", readonly = true, required = true)
+  MavenProject mavenProject;
+
+  @Parameter(defaultValue = "${session}", required = true, readonly = true)
+  MavenSession mavenSession;
+
+  @Parameter(defaultValue = "${buildNumber}")
+  String buildNumber;
+
+  @Parameter(defaultValue = "${registries}")
+  String cmdRegistriesString;
+
+  @Parameter(defaultValue = "${overrideConfigRegistries}")
+  String overrideConfigRegistries;
+
+  @Parameter(name = "moduleRegistries")
+  List<ConfigModuleRegistry> moduleRegistries;
+
+  @Parameter(name = "useModuleDescriptorsUrls")
+  String useModuleDescriptorsUrls;
+
+  @Parameter(defaultValue = "${awsRegion}")
+  String awsRegion;
+
+  @Inject ModuleRegistryProvider moduleRegistryProvider;
+  @Inject ApplicationContextBuilder applicationContextBuilder;
+
+  protected GenericApplicationContext buildApplicationContext() throws MojoExecutionException {
+    var pluginConfig = PluginConfig.builder()
+      .buildNumber(buildNumber)
+      .registries(moduleRegistries)
+      .cmdRegistryString(cmdRegistriesString)
+      .overrideConfigRegistries(parseBoolean(overrideConfigRegistries))
+      .useModuleDescriptorsUrls(parseBoolean(useModuleDescriptorsUrls))
+      .awsRegion(isNotBlank(awsRegion) ? Region.of(awsRegion) : Region.US_EAST_1)
+      .build();
+
+    var registries = moduleRegistryProvider.validateAndGetModuleRegistries(pluginConfig);
+
+    return applicationContextBuilder
+      .withLogger(getLog())
+      .withMavenProject(mavenProject)
+      .withMavenSession(mavenSession)
+      .withPluginConfig(pluginConfig)
+      .withModuleRegistries(registries)
+      .build();
+  }
+}

--- a/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
+++ b/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
@@ -59,7 +59,7 @@ public abstract class AbstractGeneratorMojo extends AbstractMojo {
     var registries = moduleRegistryProvider.validateAndGetModuleRegistries(pluginConfig);
 
     return applicationContextBuilder
-      .withLogger(getLog())
+      .withLog(getLog())
       .withMavenProject(mavenProject)
       .withMavenSession(mavenSession)
       .withPluginConfig(pluginConfig)

--- a/src/main/java/org/folio/app/generator/ConfigurationGenerator.java
+++ b/src/main/java/org/folio/app/generator/ConfigurationGenerator.java
@@ -1,0 +1,35 @@
+package org.folio.app.generator;
+
+import java.util.List;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.folio.app.generator.model.ApplicationDescriptorTemplate;
+import org.folio.app.generator.model.Dependency;
+import org.folio.app.generator.service.ApplicationDescriptorGenerator;
+
+@Mojo(name = "generateFromConfiguration", defaultPhase = LifecyclePhase.COMPILE)
+public class ConfigurationGenerator extends AbstractGeneratorMojo {
+
+  @Parameter(name = "modules")
+  List<Dependency> modules;
+
+  @Parameter(name = "uiModules")
+  List<Dependency> uiModules;
+
+  @Parameter(name = "dependencies")
+  List<Dependency> dependencies;
+
+  @Override
+  public void execute() throws MojoExecutionException {
+    var template = new ApplicationDescriptorTemplate()
+      .dependencies(dependencies)
+      .modules(modules)
+      .uiModules(uiModules);
+
+    var ctx = buildApplicationContext();
+    var appDescriptorGenerator = ctx.getBean(ApplicationDescriptorGenerator.class);
+    appDescriptorGenerator.generate(template);
+  }
+}

--- a/src/main/java/org/folio/app/generator/JsonGenerator.java
+++ b/src/main/java/org/folio/app/generator/JsonGenerator.java
@@ -1,0 +1,29 @@
+package org.folio.app.generator;
+
+import static org.apache.maven.plugins.annotations.LifecyclePhase.INITIALIZE;
+import static org.apache.maven.plugins.annotations.ResolutionScope.RUNTIME;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.folio.app.generator.service.ApplicationDescriptorGenerator;
+import org.folio.app.generator.service.JsonTemplateProvider;
+
+@Mojo(name = "generateFromJson", defaultPhase = INITIALIZE, requiresDependencyResolution = RUNTIME)
+public class JsonGenerator extends AbstractGeneratorMojo {
+
+  @Parameter(name = "templatePath", defaultValue = "${basedir}/application-template.json")
+  String templatePath;
+
+  @Override
+  public void execute() throws MojoExecutionException {
+    var ctx = buildApplicationContext();
+    ctx.registerBean("jsonTemplateProvider", JsonTemplateProvider.class);
+
+    var jsonTemplateProvider = ctx.getBean(JsonTemplateProvider.class);
+    var template = jsonTemplateProvider.readTemplate(templatePath);
+
+    var applicationDescriptorService = ctx.getBean(ApplicationDescriptorGenerator.class);
+    applicationDescriptorService.generate(template);
+  }
+}

--- a/src/main/java/org/folio/app/generator/conditions/AwsCondition.java
+++ b/src/main/java/org/folio/app/generator/conditions/AwsCondition.java
@@ -1,0 +1,17 @@
+package org.folio.app.generator.conditions;
+
+import static org.folio.app.generator.model.types.RegistryType.AWS_S3;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.lang.NonNull;
+
+public class AwsCondition implements Condition {
+
+  @Override
+  public boolean matches(ConditionContext context, @NonNull AnnotatedTypeMetadata metadata) {
+    var s3Enabled = context.getEnvironment().getProperty(AWS_S3.getPropertyName());
+    return Boolean.parseBoolean(s3Enabled);
+  }
+}

--- a/src/main/java/org/folio/app/generator/conditions/OkapiCondition.java
+++ b/src/main/java/org/folio/app/generator/conditions/OkapiCondition.java
@@ -1,0 +1,17 @@
+package org.folio.app.generator.conditions;
+
+import static org.folio.app.generator.model.types.RegistryType.OKAPI;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.lang.NonNull;
+
+public class OkapiCondition implements Condition {
+
+  @Override
+  public boolean matches(ConditionContext context, @NonNull AnnotatedTypeMetadata metadata) {
+    var okapiEnabled = context.getEnvironment().getProperty(OKAPI.getPropertyName());
+    return Boolean.parseBoolean(okapiEnabled);
+  }
+}

--- a/src/main/java/org/folio/app/generator/configuration/ApplicationContextBuilder.java
+++ b/src/main/java/org/folio/app/generator/configuration/ApplicationContextBuilder.java
@@ -14,7 +14,7 @@ import org.springframework.context.support.GenericApplicationContext;
 
 public class ApplicationContextBuilder {
 
-  private Log logger;
+  private Log log;
   private PluginConfig pluginConfig;
   private MavenProject mavenProject;
   private MavenSession mavenSession;
@@ -24,7 +24,7 @@ public class ApplicationContextBuilder {
     var context = new AnnotationConfigApplicationContext();
     setSpringContextProperties(context);
 
-    context.registerBean("mavenLogger", Log.class, () -> logger);
+    context.registerBean("mavenLogger", Log.class, () -> log);
     context.registerBean("mavenProject", MavenProject.class, () -> mavenProject);
     context.registerBean("mavenSession", MavenSession.class, () -> mavenSession);
     context.registerBean("pluginConfig", PluginConfig.class, () -> pluginConfig);
@@ -33,20 +33,16 @@ public class ApplicationContextBuilder {
 
     context.refresh();
 
-    for (var beanDefinitionName : context.getBeanDefinitionNames()) {
-      logger.info("Bean: " + beanDefinitionName);
-    }
-
     return context;
   }
 
   /**
-   * Sets logger field and returns {@link ApplicationContextBuilder}.
+   * Sets log field and returns {@link ApplicationContextBuilder}.
    *
    * @return modified {@link ApplicationContextBuilder} value
    */
-  public ApplicationContextBuilder withLogger(Log logger) {
-    this.logger = logger;
+  public ApplicationContextBuilder withLog(Log log) {
+    this.log = log;
     return this;
   }
 

--- a/src/main/java/org/folio/app/generator/configuration/ApplicationContextBuilder.java
+++ b/src/main/java/org/folio/app/generator/configuration/ApplicationContextBuilder.java
@@ -1,0 +1,95 @@
+package org.folio.app.generator.configuration;
+
+import static java.util.Collections.unmodifiableList;
+
+import java.util.List;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.folio.app.generator.model.registry.ModuleRegistries;
+import org.folio.app.generator.model.registry.ModuleRegistry;
+import org.folio.app.generator.utils.PluginConfig;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+
+public class ApplicationContextBuilder {
+
+  private Log logger;
+  private PluginConfig pluginConfig;
+  private MavenProject mavenProject;
+  private MavenSession mavenSession;
+  private List<ModuleRegistry> moduleRegistries;
+
+  public GenericApplicationContext build() {
+    var context = new AnnotationConfigApplicationContext();
+    setSpringContextProperties(context);
+
+    context.registerBean("mavenLogger", Log.class, () -> logger);
+    context.registerBean("mavenProject", MavenProject.class, () -> mavenProject);
+    context.registerBean("mavenSession", MavenSession.class, () -> mavenSession);
+    context.registerBean("pluginConfig", PluginConfig.class, () -> pluginConfig);
+    context.registerBean("moduleRegistries", ModuleRegistries.class, () -> new ModuleRegistries(moduleRegistries));
+    context.registerBean(SpringConfiguration.class);
+
+    context.refresh();
+
+    for (var beanDefinitionName : context.getBeanDefinitionNames()) {
+      logger.info("Bean: " + beanDefinitionName);
+    }
+
+    return context;
+  }
+
+  /**
+   * Sets logger field and returns {@link ApplicationContextBuilder}.
+   *
+   * @return modified {@link ApplicationContextBuilder} value
+   */
+  public ApplicationContextBuilder withLogger(Log logger) {
+    this.logger = logger;
+    return this;
+  }
+
+  /**
+   * Sets config field and returns {@link ApplicationContextBuilder}.
+   *
+   * @return modified {@link ApplicationContextBuilder} value
+   */
+  public ApplicationContextBuilder withPluginConfig(PluginConfig config) {
+    this.pluginConfig = config;
+    return this;
+  }
+
+  /**
+   * Sets mavenProject field and returns {@link ApplicationContextBuilder}.
+   *
+   * @return modified {@link ApplicationContextBuilder} value
+   */
+  public ApplicationContextBuilder withMavenProject(MavenProject mavenProject) {
+    this.mavenProject = mavenProject;
+    return this;
+  }
+
+  /**
+   * Sets mavenSession field and returns {@link ApplicationContextBuilder}.
+   *
+   * @return modified {@link ApplicationContextBuilder} value
+   */
+  public ApplicationContextBuilder withMavenSession(MavenSession mavenSession) {
+    this.mavenSession = mavenSession;
+    return this;
+  }
+
+  public ApplicationContextBuilder withModuleRegistries(List<ModuleRegistry> moduleRegistries) {
+    this.moduleRegistries = unmodifiableList(moduleRegistries);
+    return this;
+  }
+
+  private void setSpringContextProperties(GenericApplicationContext context) {
+    var usedRegistryTypes = moduleRegistries.stream().map(ModuleRegistry::getType).distinct().toList();
+    var springEnvironment = context.getEnvironment().getSystemProperties();
+    for (var usedRegistryType : usedRegistryTypes) {
+      springEnvironment.put(usedRegistryType.getPropertyName(), true);
+    }
+  }
+}

--- a/src/main/java/org/folio/app/generator/configuration/SpringConfiguration.java
+++ b/src/main/java/org/folio/app/generator/configuration/SpringConfiguration.java
@@ -1,0 +1,44 @@
+package org.folio.app.generator.configuration;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import org.folio.app.generator.conditions.AwsCondition;
+import org.folio.app.generator.conditions.OkapiCondition;
+import org.folio.app.generator.utils.PluginConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@ComponentScan("org.folio.app.generator")
+public class SpringConfiguration {
+
+  @Bean(name = "objectMapper")
+  public ObjectMapper objectMapper() {
+    return new ObjectMapper()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+      .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, false);
+  }
+
+  @Bean(name = "httpClient")
+  @Conditional(OkapiCondition.class)
+  public HttpClient httpClient() {
+    return HttpClient.newBuilder()
+      .connectTimeout(Duration.ofSeconds(30))
+      .build();
+  }
+
+  @Bean(name = "amazonS3Client")
+  @Conditional(AwsCondition.class)
+  public S3Client amazonS3Client(PluginConfig config) {
+    return S3Client.builder()
+      .region(config.getAwsRegion())
+      .credentialsProvider(DefaultCredentialsProvider.create())
+      .build();
+  }
+}

--- a/src/main/java/org/folio/app/generator/model/ApplicationDescriptor.java
+++ b/src/main/java/org/folio/app/generator/model/ApplicationDescriptor.java
@@ -1,0 +1,159 @@
+package org.folio.app.generator.model;
+
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class ApplicationDescriptor {
+
+  /**
+   * An application id, generated from name and version.
+   */
+  private String id;
+
+  /**
+   * A name of application.
+   */
+  private String name;
+
+  /**
+   * A version of application.
+   */
+  private String version;
+
+  /**
+   * A description of application.
+   */
+  private String description;
+
+  /**
+   * An application platform.
+   */
+  private String platform;
+
+  /**
+   * A list with modules to be resolved.
+   */
+  private List<ModuleDefinition> modules;
+
+  /**
+   * A list with UI modules to be resolved.
+   */
+  private List<ModuleDefinition> uiModules;
+
+  /**
+   * A list with application dependencies (they are not resolved by plugin).
+   */
+  private List<Dependency> dependencies;
+
+  /**
+   * List with module descriptor.
+   */
+  private List<Map<String, Object>> moduleDescriptors;
+
+  /**
+   * List with UI module descriptors.
+   */
+  private List<Map<String, Object>> uiModuleDescriptors;
+
+  /**
+   * Sets id field and returns {@link ApplicationDescriptor}.
+   *
+   * @return modified {@link ApplicationDescriptor} value
+   */
+  public ApplicationDescriptor id(String id) {
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * Sets name field and returns {@link ApplicationDescriptor}.
+   *
+   * @return modified {@link ApplicationDescriptor} value
+   */
+  public ApplicationDescriptor name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Sets version field and returns {@link ApplicationDescriptor}.
+   *
+   * @return modified {@link ApplicationDescriptor} value
+   */
+  public ApplicationDescriptor version(String version) {
+    this.version = version;
+    return this;
+  }
+
+  /**
+   * Sets description field and returns {@link ApplicationDescriptor}.
+   *
+   * @return modified {@link ApplicationDescriptor} value
+   */
+  public ApplicationDescriptor description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  /**
+   * Sets platform field and returns {@link ApplicationDescriptor}.
+   *
+   * @return modified {@link ApplicationDescriptor} value
+   */
+  public ApplicationDescriptor platform(String platform) {
+    this.platform = platform;
+    return this;
+  }
+
+  /**
+   * Sets modules field and returns {@link ApplicationDescriptor}.
+   *
+   * @return modified {@link ApplicationDescriptor} value
+   */
+  public ApplicationDescriptor modules(List<ModuleDefinition> modules) {
+    this.modules = modules;
+    return this;
+  }
+
+  /**
+   * Sets uiModules field and returns {@link ApplicationDescriptor}.
+   *
+   * @return modified {@link ApplicationDescriptor} value
+   */
+  public ApplicationDescriptor uiModules(List<ModuleDefinition> uiModules) {
+    this.uiModules = uiModules;
+    return this;
+  }
+
+  /**
+   * Sets dependencies field and returns {@link ApplicationDescriptor}.
+   *
+   * @return modified {@link ApplicationDescriptor} value
+   */
+  public ApplicationDescriptor dependencies(List<Dependency> dependencies) {
+    this.dependencies = dependencies;
+    return this;
+  }
+
+  /**
+   * Sets moduleDescriptors field and returns {@link ApplicationDescriptor}.
+   *
+   * @return modified {@link ApplicationDescriptor} value
+   */
+  public ApplicationDescriptor moduleDescriptors(List<Map<String, Object>> moduleDescriptors) {
+    this.moduleDescriptors = moduleDescriptors;
+    return this;
+  }
+
+  /**
+   * Sets uiModuleDescriptors field and returns {@link ApplicationDescriptor}.
+   *
+   * @return modified {@link ApplicationDescriptor} value
+   */
+  public ApplicationDescriptor uiModuleDescriptors(List<Map<String, Object>> uiModuleDescriptors) {
+    this.uiModuleDescriptors = uiModuleDescriptors;
+    return this;
+  }
+}

--- a/src/main/java/org/folio/app/generator/model/ApplicationDescriptorTemplate.java
+++ b/src/main/java/org/folio/app/generator/model/ApplicationDescriptorTemplate.java
@@ -1,0 +1,112 @@
+package org.folio.app.generator.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class ApplicationDescriptorTemplate {
+
+  /**
+   * An application id, generated from name and version.
+   */
+  private String id;
+
+  /**
+   * A name of application.
+   */
+  private String name;
+
+  /**
+   * A version of application.
+   */
+  private String version;
+
+  /**
+   * A version of application.
+   */
+  private String description;
+
+  /**
+   * A version of application.
+   */
+  private String platform;
+
+  /**
+   * A list with modules to be resolved.
+   */
+  @JsonProperty("modules")
+  private List<Dependency> modules;
+
+  /**
+   * A list with UI modules to be resolved.
+   */
+  @JsonProperty("uiModules")
+  private List<Dependency> uiModules;
+
+  /**
+   * A list with application dependencies (they are not resolved by plugin).
+   */
+  @JsonProperty("dependencies")
+  private List<Dependency> dependencies;
+
+  /**
+   * Sets id field and returns {@link ApplicationDescriptorTemplate}.
+   *
+   * @return modified {@link ApplicationDescriptorTemplate} value
+   */
+  public ApplicationDescriptorTemplate id(String id) {
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * Sets name field and returns {@link ApplicationDescriptorTemplate}.
+   *
+   * @return modified {@link ApplicationDescriptorTemplate} value
+   */
+  public ApplicationDescriptorTemplate name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Sets version field and returns {@link ApplicationDescriptorTemplate}.
+   *
+   * @return modified {@link ApplicationDescriptorTemplate} value
+   */
+  public ApplicationDescriptorTemplate version(String version) {
+    this.version = version;
+    return this;
+  }
+
+  /**
+   * Sets modules field and returns {@link ApplicationDescriptorTemplate}.
+   *
+   * @return modified {@link ApplicationDescriptorTemplate} value
+   */
+  public ApplicationDescriptorTemplate modules(List<Dependency> modules) {
+    this.modules = modules;
+    return this;
+  }
+
+  /**
+   * Sets uiModules field and returns {@link ApplicationDescriptorTemplate}.
+   *
+   * @return modified {@link ApplicationDescriptorTemplate} value
+   */
+  public ApplicationDescriptorTemplate uiModules(List<Dependency> uiModules) {
+    this.uiModules = uiModules;
+    return this;
+  }
+
+  /**
+   * Sets dependencies field and returns {@link ApplicationDescriptorTemplate}.
+   *
+   * @return modified {@link ApplicationDescriptorTemplate} value
+   */
+  public ApplicationDescriptorTemplate dependencies(List<Dependency> dependencies) {
+    this.dependencies = dependencies;
+    return this;
+  }
+}

--- a/src/main/java/org/folio/app/generator/model/Dependency.java
+++ b/src/main/java/org/folio/app/generator/model/Dependency.java
@@ -1,0 +1,17 @@
+package org.folio.app.generator.model;
+
+import lombok.Data;
+
+@Data
+public class Dependency {
+
+  /**
+   * Dependency name.
+   */
+  private String name;
+
+  /**
+   * Dependency version.
+   */
+  private String version;
+}

--- a/src/main/java/org/folio/app/generator/model/ModuleDefinition.java
+++ b/src/main/java/org/folio/app/generator/model/ModuleDefinition.java
@@ -1,0 +1,52 @@
+package org.folio.app.generator.model;
+
+import lombok.Data;
+
+@Data
+public class ModuleDefinition {
+
+  /**
+   * An artifact id.
+   */
+  private String id;
+
+  /**
+   * An artifact name.
+   */
+  private String name;
+
+  /**
+   * An artifact version.
+   */
+  private String version;
+
+  /**
+   * Sets id field and returns {@link ModuleDefinition}.
+   *
+   * @return modified {@link ModuleDefinition} value
+   */
+  public ModuleDefinition id(String id) {
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * Sets name field and returns {@link ModuleDefinition}.
+   *
+   * @return modified {@link ModuleDefinition} value
+   */
+  public ModuleDefinition name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Sets version field and returns {@link ModuleDefinition}.
+   *
+   * @return modified {@link ModuleDefinition} value
+   */
+  public ModuleDefinition version(String version) {
+    this.version = version;
+    return this;
+  }
+}

--- a/src/main/java/org/folio/app/generator/model/ModuleLoadResult.java
+++ b/src/main/java/org/folio/app/generator/model/ModuleLoadResult.java
@@ -1,0 +1,5 @@
+package org.folio.app.generator.model;
+
+import java.util.Map;
+
+public record ModuleLoadResult(ModuleDefinition artifact, Map<String, Object> descriptor) {}

--- a/src/main/java/org/folio/app/generator/model/ModulesLoadResult.java
+++ b/src/main/java/org/folio/app/generator/model/ModulesLoadResult.java
@@ -1,0 +1,6 @@
+package org.folio.app.generator.model;
+
+import java.util.List;
+import java.util.Map;
+
+public record ModulesLoadResult(List<ModuleDefinition> artifacts, List<Map<String, Object>> descriptors) {}

--- a/src/main/java/org/folio/app/generator/model/registry/ConfigModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/ConfigModuleRegistry.java
@@ -1,0 +1,32 @@
+package org.folio.app.generator.model.registry;
+
+import lombok.Data;
+
+@Data
+public class ConfigModuleRegistry {
+
+  /**
+   * Registry type - s3 or okapi.
+   */
+  private String type;
+
+  /**
+   * Public url template, where module id must have {@code {id}} placeholder.
+   */
+  private String publicUrlTemplate;
+
+  /**
+   * A base URL for http configuration.
+   */
+  private String url;
+
+  /**
+   * A path to a folder in bucket for S3 configuration.
+   */
+  private String path;
+
+  /**
+   * A name of the S3 bucket (used in S3 configuration).
+   */
+  private String bucket;
+}

--- a/src/main/java/org/folio/app/generator/model/registry/ModuleRegistries.java
+++ b/src/main/java/org/folio/app/generator/model/registry/ModuleRegistries.java
@@ -1,0 +1,5 @@
+package org.folio.app.generator.model.registry;
+
+import java.util.List;
+
+public record ModuleRegistries(List<ModuleRegistry> registries) {}

--- a/src/main/java/org/folio/app/generator/model/registry/ModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/ModuleRegistry.java
@@ -1,0 +1,38 @@
+package org.folio.app.generator.model.registry;
+
+import org.folio.app.generator.model.types.RegistryType;
+
+public interface ModuleRegistry {
+
+  /**
+   * Retrieves registry type.
+   */
+  RegistryType getType();
+
+  /**
+   * Retrieves public URL template.
+   *
+   * <p>
+   * Example: {@code http://localhost:3000/${id}}
+   * </p>
+   */
+  String getPublicUrl();
+
+  /**
+   * Self-validation method.
+   *
+   * @return true - if registry is valid, false - otherwise
+   */
+  default boolean isValid() {
+    return true;
+  }
+
+  /**
+   * A general method that tells for the implementation to generate fields, if it's required.
+   *
+   * @return new or current object as {@link ModuleRegistry}
+   */
+  default ModuleRegistry withGeneratedFields() {
+    return this;
+  }
+}

--- a/src/main/java/org/folio/app/generator/model/registry/OkapiModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/OkapiModuleRegistry.java
@@ -1,0 +1,59 @@
+package org.folio.app.generator.model.registry;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.folio.app.generator.model.types.RegistryType;
+
+@Data
+public class OkapiModuleRegistry implements ModuleRegistry {
+
+  @Setter(AccessLevel.NONE)
+  private RegistryType type = RegistryType.OKAPI;
+
+  private String url;
+  private String publicUrl;
+
+  /**
+   * Sets url field and returns {@link OkapiModuleRegistry}.
+   *
+   * @return modified {@link OkapiModuleRegistry} value
+   */
+  public OkapiModuleRegistry url(String url) {
+    this.url = url;
+    return this;
+  }
+
+  /**
+   * Sets publicUrl field and returns {@link OkapiModuleRegistry}.
+   *
+   * @return modified {@link OkapiModuleRegistry} value
+   */
+  public OkapiModuleRegistry publicUrl(String publicUrl) {
+    this.publicUrl = publicUrl;
+    return this;
+  }
+
+  @Override
+  public boolean isValid() {
+    if (isBlank(url)) {
+      return false;
+    }
+
+    try {
+      new URL(url);
+      return true;
+    } catch (MalformedURLException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public ModuleRegistry withGeneratedFields() {
+    return ModuleRegistry.super.withGeneratedFields();
+  }
+}

--- a/src/main/java/org/folio/app/generator/model/registry/S3ModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/S3ModuleRegistry.java
@@ -1,0 +1,66 @@
+package org.folio.app.generator.model.registry;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.app.generator.model.types.RegistryType;
+
+@Data
+public class S3ModuleRegistry implements ModuleRegistry {
+
+  @Setter(AccessLevel.NONE)
+  private RegistryType type = RegistryType.AWS_S3;
+
+  private String path;
+  private String bucket;
+  private String publicUrl;
+
+  /**
+   * Sets path field and returns {@link S3ModuleRegistry}.
+   *
+   * @return modified {@link S3ModuleRegistry} value
+   */
+  public S3ModuleRegistry path(String path) {
+    this.path = path;
+    return this;
+  }
+
+  /**
+   * Sets bucket field and returns {@link S3ModuleRegistry}.
+   *
+   * @return modified {@link S3ModuleRegistry} value
+   */
+  public S3ModuleRegistry bucket(String bucket) {
+    this.bucket = bucket;
+    return this;
+  }
+
+  /**
+   * Sets publicUrl field and returns {@link S3ModuleRegistry}.
+   *
+   * @return modified {@link S3ModuleRegistry} value
+   */
+  public S3ModuleRegistry publicUrl(String publicUrl) {
+    this.publicUrl = publicUrl;
+    return this;
+  }
+
+  @Override
+  public boolean isValid() {
+    return StringUtils.isNotBlank(bucket) && path != null;
+  }
+
+  @Override
+  public S3ModuleRegistry withGeneratedFields() {
+    if (isBlank(this.publicUrl)) {
+      this.publicUrl = path.isEmpty()
+        ? String.format("https://%s.s3.amazonaws.com/{id}", bucket)
+        : String.format("https://%s.s3.amazonaws.com/%s/{id}", bucket, path);
+    }
+
+    return this;
+  }
+}

--- a/src/main/java/org/folio/app/generator/model/types/RegistryType.java
+++ b/src/main/java/org/folio/app/generator/model/types/RegistryType.java
@@ -1,0 +1,15 @@
+package org.folio.app.generator.model.types;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RegistryType {
+
+  AWS_S3("s3", "folio-app-generator.s3.enabled"),
+  OKAPI("okapi", "folio-app-generator.okapi.enabled");
+
+  private final String value;
+  private final String propertyName;
+}

--- a/src/main/java/org/folio/app/generator/service/ApplicationDescriptorGenerator.java
+++ b/src/main/java/org/folio/app/generator/service/ApplicationDescriptorGenerator.java
@@ -1,0 +1,39 @@
+package org.folio.app.generator.service;
+
+import java.io.File;
+import lombok.RequiredArgsConstructor;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.folio.app.generator.model.ApplicationDescriptorTemplate;
+import org.folio.app.generator.utils.JsonConverter;
+import org.folio.app.generator.validator.ApplicationDependencyValidator;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ApplicationDescriptorGenerator {
+
+  private final MavenProject mavenProject;
+  private final JsonConverter jsonConverter;
+  private final ApplicationDependencyValidator applicationDependencyValidator;
+  private final ApplicationDescriptorService applicationDescriptorGenerator;
+
+  /**
+   * Generates application descriptor from template.
+   *
+   * @param template - application descriptor {@link ApplicationDescriptorTemplate} object
+   * @throws MojoExecutionException if application description was failed to generate
+   */
+  public void generate(ApplicationDescriptorTemplate template) throws MojoExecutionException {
+    applicationDependencyValidator.validateDependencies(template);
+    var application = applicationDescriptorGenerator.create(template);
+
+    var targetDirectory = new File(mavenProject.getBuild().getDirectory());
+    if (!targetDirectory.exists() && !targetDirectory.mkdirs()) {
+      throw new MojoExecutionException("Could not create target directory: " + targetDirectory);
+    }
+
+    var applicationDescriptorFile = new File(targetDirectory, application.getId() + ".json");
+    jsonConverter.writeValue(applicationDescriptorFile, application);
+  }
+}

--- a/src/main/java/org/folio/app/generator/service/ApplicationDescriptorService.java
+++ b/src/main/java/org/folio/app/generator/service/ApplicationDescriptorService.java
@@ -1,0 +1,104 @@
+package org.folio.app.generator.service;
+
+import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.folio.app.generator.model.ApplicationDescriptor;
+import org.folio.app.generator.model.ApplicationDescriptorTemplate;
+import org.folio.app.generator.model.Dependency;
+import org.folio.app.generator.model.ModuleDefinition;
+import org.folio.app.generator.utils.PluginConfig;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationDescriptorService {
+
+  private final MavenProject mavenProject;
+  private final PluginConfig pluginParameters;
+  private final ModuleDescriptorService moduleDescriptorService;
+
+  /**
+   * Creates {@link ApplicationDescriptor} based on template and project metadata.
+   *
+   * @param template - application descriptor template {@link ApplicationDescriptorTemplate}
+   * @return created {@link ApplicationDescriptor} with all fields.
+   */
+  public ApplicationDescriptor create(ApplicationDescriptorTemplate template) throws MojoExecutionException {
+    var name = template.getName();
+    var version = template.getVersion();
+    var baseAppDescriptor = name == null && version == null ? buildDescriptor() : buildDescriptor(template);
+
+    var modules = convertToArtifacts(template.getModules());
+    var uiModules = convertToArtifacts(template.getUiModules());
+    var modulesLoadResult = moduleDescriptorService.loadModules(modules);
+    var uiModulesLoadResult = moduleDescriptorService.loadModules(uiModules);
+
+    return baseAppDescriptor
+      .description(defaultIfBlank(template.getDescription(), mavenProject.getDescription()))
+      .platform(defaultIfBlank(template.getPlatform(), "base"))
+      .modules(modulesLoadResult.artifacts())
+      .uiModules(uiModulesLoadResult.artifacts())
+      .dependencies(emptyIfNull(template.getDependencies()))
+      .moduleDescriptors(modulesLoadResult.descriptors())
+      .uiModuleDescriptors(uiModulesLoadResult.descriptors());
+  }
+
+  private ApplicationDescriptor buildDescriptor() {
+    var applicationDescriptor = new ApplicationDescriptor();
+    var name = mavenProject.getName();
+    var version = getVersionWithBuildNumber(mavenProject.getVersion());
+
+    applicationDescriptor.setId(name + "-" + version);
+    applicationDescriptor.setName(name);
+    applicationDescriptor.setVersion(version);
+
+    return applicationDescriptor;
+  }
+
+  private ApplicationDescriptor buildDescriptor(ApplicationDescriptorTemplate template) throws MojoExecutionException {
+    var name = template.getName();
+    var version = getVersionWithBuildNumber(template.getVersion());
+
+    var applicationDescriptor = new ApplicationDescriptor();
+    applicationDescriptor.setName(name);
+    applicationDescriptor.setVersion(version);
+
+    var generatedId = name + "-" + template.getVersion();
+    if (template.getId() != null && !generatedId.equals(template.getId())) {
+      throw new MojoExecutionException("Invalid application id provided in template");
+    }
+
+    applicationDescriptor.setId(name + "-" + version);
+    return applicationDescriptor;
+  }
+
+  private List<ModuleDefinition> convertToArtifacts(List<Dependency> dependencies) {
+    return emptyIfNull(dependencies).stream()
+      .map(this::toArtifact)
+      .toList();
+  }
+
+  private ModuleDefinition toArtifact(Dependency dependency) {
+    var name = dependency.getName();
+    var version = dependency.getVersion();
+    return new ModuleDefinition().id(name + "-" + version).name(name).version(version);
+  }
+
+  public static <T> List<T> emptyIfNull(List<T> list) {
+    return list == null ? emptyList() : list;
+  }
+
+  public static String defaultIfBlank(String value, String defaultValue) {
+    return value == null || value.isBlank() ? defaultValue : value;
+  }
+
+  private String getVersionWithBuildNumber(String version) {
+    var buildNumber = pluginParameters.getBuildNumber();
+    return version.endsWith("SNAPSHOT") && isNotBlank(buildNumber) ? version + "." + buildNumber : version;
+  }
+}

--- a/src/main/java/org/folio/app/generator/service/JsonTemplateProvider.java
+++ b/src/main/java/org/folio/app/generator/service/JsonTemplateProvider.java
@@ -1,0 +1,58 @@
+package org.folio.app.generator.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Map;
+import org.apache.commons.text.StringSubstitutor;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.folio.app.generator.model.ApplicationDescriptorTemplate;
+import org.folio.app.generator.utils.JsonConverter;
+
+public class JsonTemplateProvider {
+
+  private final Log log;
+  private final JsonConverter jsonConverter;
+  private final Map<String, String> substitutionMap;
+
+  public JsonTemplateProvider(Log log, JsonConverter jsonConverter, MavenProject mavenProject) {
+    this.log = log;
+    this.jsonConverter = jsonConverter;
+    this.substitutionMap = Map.of(
+      "project.name", mavenProject.getName(),
+      "project.version", mavenProject.getVersion(),
+      "project.groupId", mavenProject.getGroupId(),
+      "project.description", mavenProject.getDescription());
+  }
+
+  /**
+   * Reads and substitutes variables in source template file.
+   *
+   * @param path - template file path
+   * @return application descriptor template as {@link ApplicationDescriptorTemplate} object
+   * @throws MojoExecutionException for any issues related to read and parse operations
+   */
+  public ApplicationDescriptorTemplate readTemplate(String path) throws MojoExecutionException {
+    var templateFile = new File(path);
+    log.debug("Template file location: " + templateFile.getAbsolutePath());
+    if (!templateFile.exists() && templateFile.isDirectory()) {
+      throw new MojoExecutionException("Template is not found: " + templateFile.getAbsolutePath());
+    }
+
+    try {
+      return readJson(templateFile);
+    } catch (IOException e) {
+      throw new MojoExecutionException("Failed to read file: " + templateFile.getAbsolutePath(), e);
+    }
+  }
+
+  private ApplicationDescriptorTemplate readJson(File f) throws IOException, MojoExecutionException {
+    var templateString = Files.readString(f.toPath(), StandardCharsets.UTF_8);
+    var stringSubstitutor = new StringSubstitutor(substitutionMap);
+    var json = stringSubstitutor.replace(templateString);
+    return jsonConverter.parse(json, ApplicationDescriptorTemplate.class);
+  }
+}

--- a/src/main/java/org/folio/app/generator/service/ModuleDescriptorService.java
+++ b/src/main/java/org/folio/app/generator/service/ModuleDescriptorService.java
@@ -1,0 +1,82 @@
+package org.folio.app.generator.service;
+
+import static org.folio.app.generator.utils.PluginUtils.createModuleDefinitionFromId;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.folio.app.generator.model.ModuleDefinition;
+import org.folio.app.generator.model.ModulesLoadResult;
+import org.folio.app.generator.model.registry.ModuleRegistries;
+import org.folio.app.generator.service.loader.ModuleDescriptorLoaderFacade;
+import org.folio.app.generator.utils.JsonConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ModuleDescriptorService {
+
+  private final JsonConverter jsonConverter;
+  private final ModuleRegistries moduleRegistries;
+  private final ModuleDescriptorLoaderFacade moduleDescriptorLoaderFacade;
+
+  /**
+   * Loads module descriptors as {@link ModulesLoadResult} for a list with module definitions.
+   *
+   * @param modules - a {@link List} with {@link ModuleDefinition} module definitions
+   * @return {@link ModulesLoadResult} with list of module definitions and module descriptors
+   * @throws MojoExecutionException if not all modules have been loaded
+   */
+  public ModulesLoadResult loadModules(List<ModuleDefinition> modules) throws MojoExecutionException {
+    var foundDescriptors = new LinkedHashMap<String, Map<String, Object>>();
+
+    for (var module : modules) {
+      var moduleId = module.getId();
+      for (var registry : moduleRegistries.registries()) {
+        if (foundDescriptors.containsKey(moduleId)) {
+          continue;
+        }
+
+        moduleDescriptorLoaderFacade.find(registry, module).ifPresent(md -> foundDescriptors.put(moduleId, md));
+      }
+    }
+
+    var allModuleIds = modules.stream().map(ModuleDefinition::getId).toList();
+    var notFoundModuleIds = new LinkedHashSet<>(allModuleIds);
+    notFoundModuleIds.removeAll(foundDescriptors.keySet());
+
+    if (!notFoundModuleIds.isEmpty()) {
+      var modulesString = notFoundModuleIds.stream().collect(Collectors.joining("\n  * ", "\n  * ", ""));
+      throw new MojoExecutionException("Failed to load module descriptors: " + modulesString);
+    }
+
+    var loadedModuleDescriptors = new ArrayList<>(foundDescriptors.values());
+    return new ModulesLoadResult(convertToArtifacts(loadedModuleDescriptors), loadedModuleDescriptors);
+  }
+
+  private ArrayList<ModuleDefinition> convertToArtifacts(Collection<Map<String, Object>> values)
+    throws MojoExecutionException {
+    var moduleDefinitions = new ArrayList<ModuleDefinition>();
+    for (var value : values) {
+      moduleDefinitions.add(convertToArtifact(value));
+    }
+
+    return moduleDefinitions;
+  }
+
+  public ModuleDefinition convertToArtifact(Map<String, Object> moduleDescriptor) throws MojoExecutionException {
+    var idField = moduleDescriptor.get("id");
+    if (!(idField instanceof String moduleId)) {
+      throw new MojoExecutionException("Loaded module id is invalid: " + jsonConverter.toJsonString(moduleDescriptor));
+    }
+
+    return createModuleDefinitionFromId(moduleId).orElseThrow(() -> new MojoExecutionException(
+      "Module cannot be created for a module descriptor:" + jsonConverter.toJsonString(moduleDescriptor)));
+  }
+}

--- a/src/main/java/org/folio/app/generator/service/ModuleRegistryProvider.java
+++ b/src/main/java/org/folio/app/generator/service/ModuleRegistryProvider.java
@@ -1,0 +1,107 @@
+package org.folio.app.generator.service;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.joining;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.removeEnd;
+import static org.apache.commons.lang3.StringUtils.removeStart;
+import static org.apache.commons.lang3.StringUtils.trim;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+import lombok.RequiredArgsConstructor;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.folio.app.generator.model.registry.ConfigModuleRegistry;
+import org.folio.app.generator.model.registry.ModuleRegistry;
+import org.folio.app.generator.model.registry.OkapiModuleRegistry;
+import org.folio.app.generator.model.registry.S3ModuleRegistry;
+import org.folio.app.generator.service.parsers.StringModuleRegistryParser;
+import org.folio.app.generator.utils.PluginConfig;
+
+@RequiredArgsConstructor(onConstructor = @__(@Inject))
+public class ModuleRegistryProvider {
+
+  private final StringModuleRegistryParser moduleRegistryParser;
+  private final List<String> supportedRegistryTypes = List.of("s3", "okapi");
+
+  /**
+   * Provides list of validated registries to load module descriptors.
+   *
+   * @param pluginConfig -  initial plugin configuration as {@link PluginConfig} object
+   * @return {@link List} with {@link ModuleRegistry} objects
+   * @throws MojoExecutionException for any errors found during registry list validations
+   */
+  public List<ModuleRegistry> validateAndGetModuleRegistries(PluginConfig pluginConfig) throws MojoExecutionException {
+    var cmdRegistryString = pluginConfig.getCmdRegistryString();
+    var invalidRegistries = new ArrayList<String>();
+    var commandLineRegistries = getCommandLineRegistries(cmdRegistryString, invalidRegistries);
+
+    if (pluginConfig.isOverrideConfigRegistries() && !commandLineRegistries.isEmpty()) {
+      handleInvalidRegistries(invalidRegistries);
+      return commandLineRegistries;
+    }
+
+    var resultModuleRegistries = new ArrayList<>(validateAndGetConfigRegistries(pluginConfig, invalidRegistries));
+    resultModuleRegistries.addAll(commandLineRegistries);
+    handleInvalidRegistries(invalidRegistries);
+    return resultModuleRegistries;
+  }
+
+  private List<ModuleRegistry> getCommandLineRegistries(String cmdRegistryString, ArrayList<String> invalidRegistries) {
+    if (isBlank(cmdRegistryString)) {
+      return emptyList();
+    }
+
+    var commandLineRegistries = new ArrayList<ModuleRegistry>();
+    var moduleRegistryStrings = cmdRegistryString.split(",");
+
+    for (var value : moduleRegistryStrings) {
+      var moduleRegistry = moduleRegistryParser.parse(value);
+      moduleRegistry.ifPresentOrElse(commandLineRegistries::add, () -> invalidRegistries.add(value));
+    }
+
+    return commandLineRegistries;
+  }
+
+  private List<ModuleRegistry> validateAndGetConfigRegistries(PluginConfig config, List<String> invalidRegistryList) {
+    var result = new ArrayList<ModuleRegistry>();
+    for (var configRegistry : config.getRegistries()) {
+      if (!supportedRegistryTypes.contains(configRegistry.getType())) {
+        invalidRegistryList.add(configRegistry.toString());
+        continue;
+      }
+
+      var registry = toModuleRegistry(configRegistry);
+
+      if (!registry.isValid()) {
+        invalidRegistryList.add(configRegistry.toString());
+      }
+
+      result.add(registry.withGeneratedFields());
+    }
+
+    return result;
+  }
+
+  private static void handleInvalidRegistries(List<String> invalidRegistries) throws MojoExecutionException {
+    if (!invalidRegistries.isEmpty()) {
+      var invalidRegistryString = invalidRegistries.stream().collect(joining("\n  * ", "\n  * ", ""));
+      throw new MojoExecutionException("Invalid registries found, "
+        + "check documentation at README.md and provided registry list:" + invalidRegistryString);
+    }
+  }
+
+  private static ModuleRegistry toModuleRegistry(ConfigModuleRegistry registry) {
+    if ("s3".equals(registry.getType())) {
+      return new S3ModuleRegistry()
+        .path(removeEnd(removeStart(trim(registry.getPath()), "/"), "/"))
+        .bucket(trim(registry.getBucket()))
+        .publicUrl(trim(registry.getPublicUrlTemplate()));
+    }
+
+    return new OkapiModuleRegistry()
+      .url(removeEnd(trim(registry.getUrl()), "/"))
+      .publicUrl(trim(registry.getPublicUrlTemplate()));
+  }
+}

--- a/src/main/java/org/folio/app/generator/service/loader/ModuleDescriptorLoader.java
+++ b/src/main/java/org/folio/app/generator/service/loader/ModuleDescriptorLoader.java
@@ -1,0 +1,14 @@
+package org.folio.app.generator.service.loader;
+
+import java.util.Map;
+import java.util.Optional;
+import org.folio.app.generator.model.ModuleDefinition;
+import org.folio.app.generator.model.registry.ModuleRegistry;
+import org.folio.app.generator.model.types.RegistryType;
+
+public interface ModuleDescriptorLoader {
+
+  Optional<Map<String, Object>> findModuleDescriptor(ModuleRegistry registry, ModuleDefinition artifact);
+
+  RegistryType getType();
+}

--- a/src/main/java/org/folio/app/generator/service/loader/ModuleDescriptorLoaderFacade.java
+++ b/src/main/java/org/folio/app/generator/service/loader/ModuleDescriptorLoaderFacade.java
@@ -22,13 +22,7 @@ public class ModuleDescriptorLoaderFacade {
   @Autowired
   public ModuleDescriptorLoaderFacade(Log log, List<ModuleDescriptorLoader> loaders) {
     this.log = log;
-    log.info("Module descriptors loaders list: " + loaders);
     this.loadersMap = loaders.stream().collect(toMap(ModuleDescriptorLoader::getType, identity()));
-
-    log.info("Module descriptors loader map: ");
-    for (var loaderEntry : this.loadersMap.entrySet()) {
-      log.info(String.format("%s: %s", loaderEntry.getKey(), loaderEntry.getValue()));
-    }
   }
 
   public Optional<Map<String, Object>> find(ModuleRegistry registry, ModuleDefinition module) {

--- a/src/main/java/org/folio/app/generator/service/loader/ModuleDescriptorLoaderFacade.java
+++ b/src/main/java/org/folio/app/generator/service/loader/ModuleDescriptorLoaderFacade.java
@@ -1,0 +1,43 @@
+package org.folio.app.generator.service.loader;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.maven.plugin.logging.Log;
+import org.folio.app.generator.model.ModuleDefinition;
+import org.folio.app.generator.model.registry.ModuleRegistry;
+import org.folio.app.generator.model.types.RegistryType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ModuleDescriptorLoaderFacade {
+
+  private final Log log;
+  private final Map<RegistryType, ModuleDescriptorLoader> loadersMap;
+
+  @Autowired
+  public ModuleDescriptorLoaderFacade(Log log, List<ModuleDescriptorLoader> loaders) {
+    this.log = log;
+    log.info("Module descriptors loaders list: " + loaders);
+    this.loadersMap = loaders.stream().collect(toMap(ModuleDescriptorLoader::getType, identity()));
+
+    log.info("Module descriptors loader map: ");
+    for (var loaderEntry : this.loadersMap.entrySet()) {
+      log.info(String.format("%s: %s", loaderEntry.getKey(), loaderEntry.getValue()));
+    }
+  }
+
+  public Optional<Map<String, Object>> find(ModuleRegistry registry, ModuleDefinition module) {
+    var moduleDescriptorLoader = loadersMap.get(registry.getType());
+    if (moduleDescriptorLoader == null) {
+      log.warn("Failed to find module descriptor loader for a registry: " + registry.getClass().getSimpleName());
+      return Optional.empty();
+    }
+
+    return moduleDescriptorLoader.findModuleDescriptor(registry, module);
+  }
+}

--- a/src/main/java/org/folio/app/generator/service/loader/OkapiModuleDescriptorLoader.java
+++ b/src/main/java/org/folio/app/generator/service/loader/OkapiModuleDescriptorLoader.java
@@ -1,0 +1,93 @@
+package org.folio.app.generator.service.loader;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.apache.maven.plugin.logging.Log;
+import org.folio.app.generator.conditions.OkapiCondition;
+import org.folio.app.generator.model.ModuleDefinition;
+import org.folio.app.generator.model.registry.ModuleRegistry;
+import org.folio.app.generator.model.registry.OkapiModuleRegistry;
+import org.folio.app.generator.model.types.RegistryType;
+import org.folio.app.generator.utils.JsonConverter;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Conditional(OkapiCondition.class)
+public class OkapiModuleDescriptorLoader implements ModuleDescriptorLoader {
+
+  private final Log log;
+  private final HttpClient httpClient;
+  private final JsonConverter jsonConverter;
+
+  @Override
+  public Optional<Map<String, Object>> findModuleDescriptor(ModuleRegistry registry, ModuleDefinition module) {
+    var okapiRegistry = (OkapiModuleRegistry) registry;
+    var url = okapiRegistry.getUrl();
+    try {
+      return loadModuleDescriptor(url, module);
+    } catch (Exception e) {
+      log.warn(String.format("Failed to load module descriptor '%s' from %s", module.getId(), url), e);
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public RegistryType getType() {
+    return RegistryType.OKAPI;
+  }
+
+  private Optional<Map<String, Object>> loadModuleDescriptor(String url, ModuleDefinition module) throws Exception {
+    var request = prepareHttpRequest(url, module);
+    var moduleId = module.getId();
+
+    var response = httpClient.send(request, BodyHandlers.ofInputStream());
+    var responseStatus = response.statusCode();
+    if (responseStatus != 200) {
+      log.warn(String.format("Failed to load module descriptor '%s' from %s", url, responseStatus));
+      return Optional.empty();
+    }
+
+    var searchResult = jsonConverter.parse(response.body(), new TypeReference<List<Map<String, Object>>>() {});
+    if (searchResult.isEmpty()) {
+      log.warn(String.format("Module descriptor '%s' is not found in %s", moduleId, url));
+      return Optional.empty();
+    }
+
+    log.info(String.format("Module descriptor '%s' loaded from %s", moduleId, url));
+    return Optional.of(searchResult.get(0));
+  }
+
+  private static HttpRequest prepareHttpRequest(String url, ModuleDefinition module) {
+    var baseUrl = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    return HttpRequest.newBuilder()
+      .GET()
+      .uri(URI.create(prepareUriString(baseUrl, module)))
+      .timeout(Duration.ofMinutes(5))
+      .version(Version.HTTP_1_1)
+      .build();
+  }
+
+  private static String prepareUriString(String baseUrl, ModuleDefinition module) {
+    var moduleName = module.getName();
+    var version = module.getVersion();
+    var filter = "latest".equals(version) ? moduleName : module.getId();
+
+    return baseUrl + "/_/proxy/modules"
+      + "?filter=" + filter
+      + "&latest=1"
+      + "&orderBy=id"
+      + "&order=desc"
+      + "&full=true";
+  }
+}

--- a/src/main/java/org/folio/app/generator/service/loader/S3ModuleDescriptorLoader.java
+++ b/src/main/java/org/folio/app/generator/service/loader/S3ModuleDescriptorLoader.java
@@ -1,0 +1,137 @@
+package org.folio.app.generator.service.loader;
+
+import static java.util.Optional.ofNullable;
+import static org.folio.app.generator.utils.PluginUtils.createModuleDefinitionFromId;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.maven.plugin.logging.Log;
+import org.folio.app.generator.conditions.AwsCondition;
+import org.folio.app.generator.model.ModuleDefinition;
+import org.folio.app.generator.model.registry.ModuleRegistry;
+import org.folio.app.generator.model.registry.S3ModuleRegistry;
+import org.folio.app.generator.model.types.RegistryType;
+import org.folio.app.generator.utils.JsonConverter;
+import org.folio.app.generator.utils.PluginConfig;
+import org.semver4j.Semver;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+@Component
+@RequiredArgsConstructor
+@Conditional(AwsCondition.class)
+public class S3ModuleDescriptorLoader implements ModuleDescriptorLoader {
+
+  private final Log log;
+  private final S3Client s3Client;
+  private final PluginConfig pluginConfig;
+  private final JsonConverter jsonConverter;
+
+  @Override
+  public Optional<Map<String, Object>> findModuleDescriptor(ModuleRegistry registry, ModuleDefinition module) {
+    var s3Registry = (S3ModuleRegistry) registry;
+    var version = module.getVersion();
+    var filter = "latest".equals(version) ? module.getName() : module.getId();
+    var s3RegistryPath = s3Registry.getPath();
+    var pathPrefix = s3RegistryPath.isEmpty() ? s3RegistryPath : s3RegistryPath + "/";
+    var fullPrefix = pathPrefix + filter;
+
+    return findLatestVersionByPrefix(s3Registry, pathPrefix, fullPrefix)
+      .flatMap(foundS3Object -> readS3Object(foundS3Object, s3Registry));
+  }
+
+  @Override
+  public RegistryType getType() {
+    return RegistryType.AWS_S3;
+  }
+
+  private Optional<S3Object> findLatestVersionByPrefix(S3ModuleRegistry s3Registry, String pathPrefix, String prefix) {
+    var request = buildListObjectsRequest(s3Registry, prefix, null);
+
+    ListObjectsV2Response result;
+    Pair<Semver, S3Object> maxValueHolder = null;
+
+    do {
+      result = s3Client.listObjectsV2(request);
+      var s3ObjectsByPrefix = result.contents();
+      if (s3ObjectsByPrefix.isEmpty()) {
+        return Optional.empty();
+      }
+
+      for (var s3Object : s3ObjectsByPrefix) {
+        var nextMaxValue = tryFindNextMaxValue(pathPrefix, s3Object, maxValueHolder);
+        if (nextMaxValue != null) {
+          maxValueHolder = nextMaxValue;
+        }
+      }
+
+      request = buildListObjectsRequest(s3Registry, prefix, result.nextContinuationToken());
+    } while (result.isTruncated());
+
+    return ofNullable(maxValueHolder).map(Pair::getRight);
+  }
+
+  private static Pair<Semver, S3Object> tryFindNextMaxValue(String prefix, S3Object o, Pair<Semver, S3Object> mv) {
+    var currentSemver = parseModuleVersion(o, prefix);
+    if (mv == null) {
+      return Pair.of(currentSemver, o);
+    }
+
+    if (currentSemver == null) {
+      return null;
+    }
+
+    var maxSemver = mv.getLeft();
+    if (maxSemver == null || currentSemver.compareTo(maxSemver) > 0) {
+      return Pair.of(currentSemver, o);
+    }
+
+    return null;
+  }
+
+  private Optional<Map<String, Object>> readS3Object(S3Object object, S3ModuleRegistry registry) {
+    var request = GetObjectRequest.builder()
+      .bucket(registry.getBucket())
+      .key(object.key())
+      .build();
+
+    var responseBytes = s3Client.getObject(request, ResponseTransformer.toBytes());
+    try {
+      return Optional.ofNullable(jsonConverter.parse(responseBytes.asInputStream(), new TypeReference<>() {}));
+    } catch (Exception exception) {
+      log.warn("Failed to get content from s3 object by key: " + object.key(), exception);
+      return Optional.empty();
+    }
+  }
+
+  private ListObjectsV2Request buildListObjectsRequest(S3ModuleRegistry registry, String prefix, String nct) {
+    return ListObjectsV2Request.builder()
+      .bucket(registry.getBucket())
+      .prefix(prefix)
+      .maxKeys(pluginConfig.getAwsS3BatchSize())
+      .continuationToken(nct)
+      .build();
+  }
+
+  private static Semver parseModuleVersion(S3Object s3Object, String pathPrefix) {
+    var s3ObjectKey = s3Object.key();
+    var fileName = s3ObjectKey.substring(pathPrefix.length());
+    if (!fileName.endsWith(".json")) {
+      return null;
+    }
+
+    return createModuleDefinitionFromId(fileName.substring(0, fileName.length() - 5))
+      .map(ModuleDefinition::getVersion)
+      .map(Semver::parse)
+      .orElse(null);
+  }
+}

--- a/src/main/java/org/folio/app/generator/service/parsers/StringModuleRegistryParser.java
+++ b/src/main/java/org/folio/app/generator/service/parsers/StringModuleRegistryParser.java
@@ -1,0 +1,97 @@
+package org.folio.app.generator.service.parsers;
+
+import static org.apache.commons.lang3.StringUtils.removeEnd;
+import static org.apache.commons.lang3.StringUtils.removeStart;
+import static org.apache.commons.lang3.StringUtils.trim;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.app.generator.model.registry.ModuleRegistry;
+import org.folio.app.generator.model.registry.OkapiModuleRegistry;
+import org.folio.app.generator.model.registry.S3ModuleRegistry;
+
+public class StringModuleRegistryParser {
+
+  private final Pattern okapiPattern1 = Pattern.compile("(okapi)::(.+)::(.+)");
+  private final Pattern okapiPattern2 = Pattern.compile("(okapi)::(.+)");
+  private final Pattern s3Pattern1 = Pattern.compile("(s3)::(.+)::(.+)::(.+)");
+  private final Pattern s3Pattern2 = Pattern.compile("(s3)::(.+)::(.+)");
+
+  private final List<Pair<Pattern, Function<String[], ModuleRegistry>>> patterns = List.of(
+    Pair.of(okapiPattern1, StringModuleRegistryParser::parseOkapiString),
+    Pair.of(okapiPattern2, StringModuleRegistryParser::parseOkapiString),
+    Pair.of(s3Pattern1, StringModuleRegistryParser::parseAwsS3String),
+    Pair.of(s3Pattern2, StringModuleRegistryParser::parseAwsS3String));
+
+  /**
+   * Parses module registry string to a {@link ModuleRegistry} object.
+   *
+   * @param sourceValue - {@link String} value to parse.
+   * @return {@link Optional} of {@link ModuleRegistry} object, it will be null if source string is not compatible
+   */
+  public Optional<ModuleRegistry> parse(String sourceValue) {
+    for (var patternPair : patterns) {
+      var pattern = patternPair.getLeft();
+      var matcher = pattern.matcher(sourceValue);
+      if (matcher.matches()) {
+        var stringParts = convertToStringPartsArray(matcher);
+        return Optional.of(patternPair.getRight().apply(stringParts));
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static String[] convertToStringPartsArray(Matcher matcher) {
+    var groupCount = matcher.groupCount();
+    var pathParts = new String[groupCount];
+    for (int i = 1; i <= groupCount; i++) {
+      pathParts[i - 1] = matcher.group(i);
+    }
+    return pathParts;
+  }
+
+  private static ModuleRegistry parseOkapiString(String[] stringParts) {
+    var baseUrl = checkAndGetUrl(stringParts[1]);
+    var verifiedUrl = baseUrl.toString();
+
+    var s3ModuleRegistry = new OkapiModuleRegistry();
+    s3ModuleRegistry.setUrl(verifiedUrl);
+
+    if (stringParts.length == 2) {
+      s3ModuleRegistry.setPublicUrl(verifiedUrl + "/_/proxy/modules/{id}");
+    } else {
+      s3ModuleRegistry.setPublicUrl(trim(stringParts[2]));
+    }
+
+    return s3ModuleRegistry;
+  }
+
+  private static URL checkAndGetUrl(String probablyUrl) {
+    try {
+      return new URL(removeEnd(probablyUrl, "/"));
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException("Invalid url provided: " + probablyUrl, e);
+    }
+  }
+
+  private static S3ModuleRegistry parseAwsS3String(String[] stringParts) {
+    var s3ModuleRegistry = new S3ModuleRegistry();
+    var bucket = stringParts[1];
+    var path = removeEnd(removeStart(trim(stringParts[2]), "/"), "/");
+
+    s3ModuleRegistry.setBucket(trim(bucket));
+    s3ModuleRegistry.setPath(path);
+
+    if (stringParts.length == 4) {
+      s3ModuleRegistry.setPublicUrl(trim(stringParts[3]));
+    }
+
+    return s3ModuleRegistry.withGeneratedFields();
+  }
+}

--- a/src/main/java/org/folio/app/generator/utils/JsonConverter.java
+++ b/src/main/java/org/folio/app/generator/utils/JsonConverter.java
@@ -1,0 +1,58 @@
+package org.folio.app.generator.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.SerializationException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JsonConverter {
+
+  private final ObjectMapper objectMapper;
+
+  public <T> T parse(File file, Class<T> targetClass) {
+    try {
+      return objectMapper.readValue(file, targetClass);
+    } catch (IOException e) {
+      throw new SerializationException("Failed to read value from file: " + file.getAbsolutePath(), e);
+    }
+  }
+
+  public <T> T parse(String json, Class<T> targetClass) {
+    try {
+      return objectMapper.readValue(json, targetClass);
+    } catch (IOException e) {
+      throw new SerializationException("Failed to read value from string", e);
+    }
+  }
+
+  public <T> T parse(InputStream inputStream, TypeReference<T> typeReference) {
+    try {
+      return objectMapper.readValue(inputStream, typeReference);
+    } catch (IOException e) {
+      throw new SerializationException("Failed to parse value from input stream", e);
+    }
+  }
+
+  public void writeValue(File file, Object value) {
+    try {
+      objectMapper.writeValue(file, value);
+    } catch (IOException e) {
+      throw new SerializationException("Failed to write value to file: " + file.getAbsolutePath(), e);
+    }
+  }
+
+  public String toJsonString(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException e) {
+      throw new SerializationException("Failed to convert value to json", e);
+    }
+  }
+}

--- a/src/main/java/org/folio/app/generator/utils/PluginConfig.java
+++ b/src/main/java/org/folio/app/generator/utils/PluginConfig.java
@@ -1,0 +1,26 @@
+package org.folio.app.generator.utils;
+
+import java.net.URI;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+import org.folio.app.generator.model.registry.ConfigModuleRegistry;
+import software.amazon.awssdk.regions.Region;
+
+@Data
+@Builder
+public class PluginConfig {
+
+  private final String buildNumber;
+  private final List<ConfigModuleRegistry> registries;
+
+  private final String cmdRegistryString;
+  private final boolean useModuleDescriptorsUrls;
+  private final boolean overrideConfigRegistries;
+
+  private final Region awsRegion;
+  private final URI awsEndpointOverride;
+
+  @Builder.Default
+  private final int awsS3BatchSize = 1000;
+}

--- a/src/main/java/org/folio/app/generator/utils/PluginUtils.java
+++ b/src/main/java/org/folio/app/generator/utils/PluginUtils.java
@@ -1,0 +1,23 @@
+package org.folio.app.generator.utils;
+
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.folio.app.generator.model.ModuleDefinition;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PluginUtils {
+
+  public static Optional<ModuleDefinition> createModuleDefinitionFromId(String moduleId) {
+    for (int i = 0; i < moduleId.length() - 1; i++) {
+      if (moduleId.charAt(i) == '-' && Character.isDigit(moduleId.charAt(i + 1))) {
+        return Optional.of(new ModuleDefinition()
+          .id(moduleId)
+          .name(moduleId.substring(0, i))
+          .version(moduleId.substring(i + 1)));
+      }
+    }
+
+    return Optional.empty();
+  }
+}

--- a/src/main/java/org/folio/app/generator/validator/ApplicationDependencyValidator.java
+++ b/src/main/java/org/folio/app/generator/validator/ApplicationDependencyValidator.java
@@ -1,0 +1,107 @@
+package org.folio.app.generator.validator;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.folio.app.generator.model.ApplicationDescriptorTemplate;
+import org.folio.app.generator.model.Dependency;
+import org.semver4j.Semver;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ApplicationDependencyValidator {
+
+  private final Log log;
+  private final MavenProject mavenProject;
+  private final Set<String> reservedVersionKeywords = Set.of("latest");
+
+  /**
+   * Validates that all dependencies satisfies specific release and declared in a right way.
+   *
+   * @param template - {@link ApplicationDescriptorTemplate} to analyze
+   * @throws MojoExecutionException - if any validation error occurred
+   */
+  public void validateDependencies(ApplicationDescriptorTemplate template) throws MojoExecutionException {
+    var projectVersion = validateAndGetProjectVersion(template);
+    var errors = Stream.of(template.getModules(), template.getUiModules(), template.getDependencies())
+      .map(dependencies -> getValidationErrors(projectVersion, dependencies))
+      .flatMap(Collection::stream)
+      .toList();
+
+    if (!errors.isEmpty()) {
+      var errorsString = errors.stream().collect(Collectors.joining("\n  * ", "  * ", ""));
+      throw new IllegalArgumentException("Invalid dependencies found:\n" + errorsString);
+    }
+  }
+
+  private List<String> getValidationErrors(Semver projectVersion, List<Dependency> dependencies) {
+    if (dependencies == null || dependencies.isEmpty()) {
+      return emptyList();
+    }
+
+    var errors = new ArrayList<String>();
+    boolean isProjectHasFixVersion = projectVersion.getPreRelease().isEmpty();
+    log.debug("Is pre-release application descriptor: " + isProjectHasFixVersion);
+
+    for (int i = 0; i < dependencies.size(); i++) {
+      Dependency dependency = dependencies.get(i);
+      var name = dependency.getName();
+      if (StringUtils.isBlank(name)) {
+        errors.add("Dependency name cannot be empty at index: " + i);
+        continue;
+      }
+
+      var version = dependency.getVersion();
+      var parsedVersion = Semver.parse(version);
+      if (parsedVersion == null) {
+        if (!reservedVersionKeywords.contains(version)) {
+          errors.add(format("Dependency '%s' version '%s' must satisfy semver", name, version));
+          continue;
+        }
+
+        if (isProjectHasFixVersion) {
+          errors.add(format("Dependency '%s' version '%s' must be stable for a stable release", name, version));
+          continue;
+        }
+      }
+
+      if (isProjectHasFixVersion && !parsedVersion.getPreRelease().isEmpty()) {
+        errors.add(format("Dependency '%s' version '%s' must be stable for a stable release", name, version));
+      }
+    }
+
+    return errors;
+  }
+
+  private Semver validateAndGetProjectVersion(ApplicationDescriptorTemplate template) throws MojoExecutionException {
+    var templateVersion = template.getVersion();
+    if (templateVersion != null) {
+      var parsedTemplateVersion = Semver.parse(templateVersion);
+      if (parsedTemplateVersion == null) {
+        throw new MojoExecutionException("Template version must satisfy semver: " + templateVersion);
+      }
+
+      return parsedTemplateVersion;
+    }
+
+    var projectVersion = mavenProject.getVersion();
+    var parsedProjectVersion = Semver.parse(projectVersion);
+    if (parsedProjectVersion == null) {
+      throw new MojoExecutionException("Project version must satisfy semver: " + projectVersion);
+    }
+
+    return parsedProjectVersion;
+  }
+}

--- a/src/test/java/org/folio/app/generator/service/parsers/StringModuleRegistryParserTest.java
+++ b/src/test/java/org/folio/app/generator/service/parsers/StringModuleRegistryParserTest.java
@@ -1,0 +1,97 @@
+package org.folio.app.generator.service.parsers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.folio.app.generator.model.registry.ModuleRegistry;
+import org.folio.app.generator.model.registry.OkapiModuleRegistry;
+import org.folio.app.generator.model.registry.S3ModuleRegistry;
+import org.folio.app.generator.support.UnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class StringModuleRegistryParserTest {
+
+  @InjectMocks private StringModuleRegistryParser moduleRegistryProcessor;
+
+  @DisplayName("parseRegistryString_parameterized")
+  @ParameterizedTest(name = "[{index}] sourceString = {0}")
+  @MethodSource("registryStringDataSource")
+  void parseModuleRegistryString_parameterized(String value, ModuleRegistry expected) {
+    var moduleRegistry = moduleRegistryProcessor.parse(value);
+    assertThat(moduleRegistry).isEqualTo(Optional.ofNullable(expected));
+  }
+
+  @Test
+  void parseModuleRegistryString_invalidUrl() {
+    var sourceString = "okapi::invalid-url";
+    assertThatThrownBy(() -> moduleRegistryProcessor.parse(sourceString))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid url provided: invalid-url");
+  }
+
+  public static Stream<Arguments> registryStringDataSource() {
+    return Stream.of(
+      arguments("http://localhost:3000", null),
+      arguments("okapi::http://localhost:3000", okapiModuleRegistry("http://localhost:3000")),
+      arguments("okapi::  http://localhost:3000", okapiModuleRegistry("http://localhost:3000")),
+      arguments("okapi::http://localhost:3000/", okapiModuleRegistry("http://localhost:3000")),
+      arguments("okapi::https://test-okapi.sample", okapiModuleRegistry("https://test-okapi.sample")),
+      arguments("okapi::https://test-okapi.sample/", okapiModuleRegistry("https://test-okapi.sample")),
+
+      arguments("okapi::http://localhost:3000::https://test-okapi.sample/${id}",
+        okapiModuleRegistry("http://localhost:3000", "https://test-okapi.sample/${id}")),
+      arguments("okapi::  http://localhost:3000  :: https://test-okapi.sample/${id}  ",
+        okapiModuleRegistry("http://localhost:3000", "https://test-okapi.sample/${id}")),
+      arguments("okapi::https://test-okapi.sample::https://test-host.sample/okapi/${id}",
+        okapiModuleRegistry("https://test-okapi.sample", "https://test-host.sample/okapi/${id}")),
+
+      arguments("s3::test-bucket::/", s3ModuleRegistry("test-bucket", "")),
+      arguments("s3::test-bucket::test", s3ModuleRegistry("test-bucket", "test")),
+      arguments("s3::test-bucket::/test", s3ModuleRegistry("test-bucket", "test")),
+      arguments("s3::  test-bucket  ::  /test", s3ModuleRegistry("test-bucket", "test")),
+      arguments("s3::foo-bucket::/foo/bar", s3ModuleRegistry("foo-bucket", "foo/bar")),
+      arguments("s3::foo-bucket::/foo/bar/", s3ModuleRegistry("foo-bucket", "foo/bar")),
+
+      arguments("s3::test-bucket::/foo/bar/::https://s3-alias.sample/${id}",
+        s3ModuleRegistry("test-bucket", "foo/bar", "https://s3-alias.sample/${id}"))
+    );
+  }
+
+  private static Object okapiModuleRegistry(String url) {
+    return okapiModuleRegistry(url, url + "/_/proxy/modules/{id}");
+  }
+
+  private static Object okapiModuleRegistry(String url, String publicUrlTemplate) {
+    var registry = new OkapiModuleRegistry();
+    registry.setUrl(url);
+    registry.setPublicUrl(publicUrlTemplate);
+    return registry;
+  }
+
+  private static S3ModuleRegistry s3ModuleRegistry(String bucket, String path) {
+    var publicUrlTemplate = path.isEmpty()
+      ? String.format("https://%s.s3.amazonaws.com/{id}", bucket)
+      : String.format("https://%s.s3.amazonaws.com/%s/{id}", bucket, path);
+    return s3ModuleRegistry(bucket, path, publicUrlTemplate);
+  }
+
+  private static S3ModuleRegistry s3ModuleRegistry(String bucket, String path, String publicUrl) {
+    var registry = new S3ModuleRegistry();
+    registry.setBucket(bucket);
+    registry.setPath(path);
+    registry.setPublicUrl(publicUrl);
+    return registry;
+  }
+}

--- a/src/test/java/org/folio/app/generator/support/IntegrationTest.java
+++ b/src/test/java/org/folio/app/generator/support/IntegrationTest.java
@@ -1,0 +1,15 @@
+package org.folio.app.generator.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Marks test as unit.
+ */
+@Tag("integration")
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface IntegrationTest {}

--- a/src/test/java/org/folio/app/generator/support/UnitTest.java
+++ b/src/test/java/org/folio/app/generator/support/UnitTest.java
@@ -1,0 +1,15 @@
+package org.folio.app.generator.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Marks test as unit.
+ */
+@Tag("unit")
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface UnitTest {}


### PR DESCRIPTION
### Purpose

Create a Maven plugin that will handle application generation based on the provided template or Maven plugin configuration and generate a working application.

US: [APPDESCRIP-4](https://folio-org.atlassian.net/browse/APPDESCRIP-4)

#### JSON-based generator
Default template location in the root: `${baseDir/application-template.json}`
Configuration example:
```xml
<plugin>
  <groupId>org.folio</groupId>
  <artifactId>folio-application-generator</artifactId>
  <version>0.0.1-SNAPSHOT</version>
  <executions>
    <execution>
      <goals>
        <goal>generateFromJson</goal>
      </goals>
    </execution>
  </executions>
  <configuration>
    <moduleRegistries>
      <registry>
        <type>okapi</type>
        <url>https://folio-registry.dev.folio.org</url>
      </registry>
    </moduleRegistries>
  </configuration>
</plugin>
```

Template example:
```json
{
  "name": "${project.name}",
  "version": "${project.version}",
  "platform": "base",
  "dependencies": [],
  "modules": [
    {
      "name": "mod-users-keycloak",
      "version": "1.1.0-SNAPSHOT"
    }
  ],
  "uiModules": []
}

```

#### Configuration-based generator:
```xml
<plugin>
  <groupId>org.folio</groupId>
  <artifactId>folio-application-generator</artifactId>
  <version>0.0.1-SNAPSHOT</version>
  <executions>
    <execution>
      <goals>
        <goal>generateFromConfiguration</goal>
      </goals>
    </execution>
  </executions>
  <configuration>
    <modules>
      <module>
        <name>mod-users-keycloak</name>
        <version>1.1.0-SNAPSHOT</version>
      </module>
    </modules>
    <moduleRegistries>
      <registry>
        <type>okapi</type>
        <url>https://folio-registry.dev.folio.org</url>
      </registry>
    </moduleRegistries>
  </configuration>
</plugin>
```

#### Plugin command-line parameters

- `buildNumber` - will add `.${buildNumber} to the end of the `applicationId` and `version` if its a `-SNAPSHOT` version
- `registries` - provides a way to add additional registries, examples 
  - `okapi::http://localhost:3000`
  - `s3::test-bucket::test-folder`
- `overrideConfigRegistries` - defines if only registries from command line parameters must be used
- `awsRegion` - provides aws region, by default, it will be `us-east-1`

### Approach
- Add a configuration-based generator
- Add a JSON-template-based generator
- Use dependency injection for plugin components
- Implement loading of descriptors from the Okapi registry
- Implement loading of descriptors from AWS S3 bucket
- Add a string substitution for a JSON template (project's name, group, version, description)
- Add spring-core for dependency management
- Fix system properties for conditional beans
- Implement template formatting
- Add a Checkstyle plugin
- Add unit tests plugin