### PR TITLE
APPDESCRIP-4 Fix sonarcloud code smells

### DIFF
--- a/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
+++ b/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
@@ -47,7 +47,7 @@ public abstract class AbstractGeneratorMojo extends AbstractMojo {
   protected final ApplicationContextBuilder applicationContextBuilder;
 
   @Inject
-  public AbstractGeneratorMojo(ModuleRegistryProvider registryProvider, ApplicationContextBuilder contextBuilder) {
+  protected AbstractGeneratorMojo(ModuleRegistryProvider registryProvider, ApplicationContextBuilder contextBuilder) {
     this.moduleRegistryProvider = registryProvider;
     this.applicationContextBuilder = contextBuilder;
   }

--- a/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
+++ b/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
@@ -20,31 +20,37 @@ import software.amazon.awssdk.regions.Region;
 public abstract class AbstractGeneratorMojo extends AbstractMojo {
 
   @Parameter(defaultValue = "${project}", readonly = true, required = true)
-  MavenProject mavenProject;
+  protected MavenProject mavenProject;
 
   @Parameter(defaultValue = "${session}", required = true, readonly = true)
-  MavenSession mavenSession;
+  protected MavenSession mavenSession;
 
   @Parameter(defaultValue = "${buildNumber}")
-  String buildNumber;
+  protected String buildNumber;
 
   @Parameter(defaultValue = "${registries}")
-  String cmdRegistriesString;
+  protected String cmdRegistriesString;
 
   @Parameter(defaultValue = "${overrideConfigRegistries}")
-  String overrideConfigRegistries;
+  protected String overrideConfigRegistries;
 
   @Parameter(name = "moduleRegistries")
-  List<ConfigModuleRegistry> moduleRegistries;
+  protected List<ConfigModuleRegistry> moduleRegistries;
 
   @Parameter(name = "useModuleDescriptorsUrls")
-  String useModuleDescriptorsUrls;
+  protected String useModuleDescriptorsUrls;
 
   @Parameter(defaultValue = "${awsRegion}")
-  String awsRegion;
+  protected String awsRegion;
 
-  @Inject ModuleRegistryProvider moduleRegistryProvider;
-  @Inject ApplicationContextBuilder applicationContextBuilder;
+  protected final ModuleRegistryProvider moduleRegistryProvider;
+  protected final ApplicationContextBuilder applicationContextBuilder;
+
+  @Inject
+  public AbstractGeneratorMojo(ModuleRegistryProvider registryProvider, ApplicationContextBuilder contextBuilder) {
+    this.moduleRegistryProvider = registryProvider;
+    this.applicationContextBuilder = contextBuilder;
+  }
 
   protected GenericApplicationContext buildApplicationContext() throws MojoExecutionException {
     var pluginConfig = PluginConfig.builder()

--- a/src/main/java/org/folio/app/generator/ConfigurationGenerator.java
+++ b/src/main/java/org/folio/app/generator/ConfigurationGenerator.java
@@ -1,13 +1,16 @@
 package org.folio.app.generator;
 
 import java.util.List;
+import javax.inject.Inject;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.folio.app.generator.configuration.ApplicationContextBuilder;
 import org.folio.app.generator.model.ApplicationDescriptorTemplate;
 import org.folio.app.generator.model.Dependency;
 import org.folio.app.generator.service.ApplicationDescriptorGenerator;
+import org.folio.app.generator.service.ModuleRegistryProvider;
 
 @Mojo(name = "generateFromConfiguration", defaultPhase = LifecyclePhase.COMPILE)
 public class ConfigurationGenerator extends AbstractGeneratorMojo {
@@ -20,6 +23,11 @@ public class ConfigurationGenerator extends AbstractGeneratorMojo {
 
   @Parameter(name = "dependencies")
   List<Dependency> dependencies;
+
+  @Inject
+  public ConfigurationGenerator(ModuleRegistryProvider registryProvider, ApplicationContextBuilder contextBuilder) {
+    super(registryProvider, contextBuilder);
+  }
 
   @Override
   public void execute() throws MojoExecutionException {

--- a/src/main/java/org/folio/app/generator/JsonGenerator.java
+++ b/src/main/java/org/folio/app/generator/JsonGenerator.java
@@ -1,19 +1,27 @@
 package org.folio.app.generator;
 
-import static org.apache.maven.plugins.annotations.LifecyclePhase.INITIALIZE;
 import static org.apache.maven.plugins.annotations.ResolutionScope.RUNTIME;
 
+import javax.inject.Inject;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.folio.app.generator.configuration.ApplicationContextBuilder;
 import org.folio.app.generator.service.ApplicationDescriptorGenerator;
 import org.folio.app.generator.service.JsonTemplateProvider;
+import org.folio.app.generator.service.ModuleRegistryProvider;
 
-@Mojo(name = "generateFromJson", defaultPhase = INITIALIZE, requiresDependencyResolution = RUNTIME)
+@Mojo(name = "generateFromJson", defaultPhase = LifecyclePhase.COMPILE, requiresDependencyResolution = RUNTIME)
 public class JsonGenerator extends AbstractGeneratorMojo {
 
   @Parameter(name = "templatePath", defaultValue = "${basedir}/application-template.json")
   String templatePath;
+
+  @Inject
+  public JsonGenerator(ModuleRegistryProvider registryProvider, ApplicationContextBuilder contextBuilder) {
+    super(registryProvider, contextBuilder);
+  }
 
   @Override
   public void execute() throws MojoExecutionException {

--- a/src/main/java/org/folio/app/generator/model/registry/OkapiModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/OkapiModuleRegistry.java
@@ -53,7 +53,11 @@ public class OkapiModuleRegistry implements ModuleRegistry {
   }
 
   @Override
-  public ModuleRegistry withGeneratedFields() {
-    return ModuleRegistry.super.withGeneratedFields();
+  public OkapiModuleRegistry withGeneratedFields() {
+    if (this.publicUrl == null) {
+      this.publicUrl = this.url + "/_/proxy/modules/{id}";
+    }
+
+    return this;
   }
 }

--- a/src/main/java/org/folio/app/generator/service/ApplicationDescriptorGenerator.java
+++ b/src/main/java/org/folio/app/generator/service/ApplicationDescriptorGenerator.java
@@ -15,8 +15,8 @@ public class ApplicationDescriptorGenerator {
 
   private final MavenProject mavenProject;
   private final JsonConverter jsonConverter;
+  private final ApplicationDescriptorService applicationDescriptorService;
   private final ApplicationDependencyValidator applicationDependencyValidator;
-  private final ApplicationDescriptorService applicationDescriptorGenerator;
 
   /**
    * Generates application descriptor from template.
@@ -26,7 +26,7 @@ public class ApplicationDescriptorGenerator {
    */
   public void generate(ApplicationDescriptorTemplate template) throws MojoExecutionException {
     applicationDependencyValidator.validateDependencies(template);
-    var application = applicationDescriptorGenerator.create(template);
+    var application = applicationDescriptorService.create(template);
 
     var targetDirectory = new File(mavenProject.getBuild().getDirectory());
     if (!targetDirectory.exists() && !targetDirectory.mkdirs()) {

--- a/src/main/java/org/folio/app/generator/service/JsonTemplateProvider.java
+++ b/src/main/java/org/folio/app/generator/service/JsonTemplateProvider.java
@@ -49,7 +49,7 @@ public class JsonTemplateProvider {
     }
   }
 
-  private ApplicationDescriptorTemplate readJson(File f) throws IOException, MojoExecutionException {
+  private ApplicationDescriptorTemplate readJson(File f) throws IOException {
     var templateString = Files.readString(f.toPath(), StandardCharsets.UTF_8);
     var stringSubstitutor = new StringSubstitutor(substitutionMap);
     var json = stringSubstitutor.replace(templateString);

--- a/src/main/java/org/folio/app/generator/service/ModuleDescriptorService.java
+++ b/src/main/java/org/folio/app/generator/service/ModuleDescriptorService.java
@@ -1,5 +1,6 @@
 package org.folio.app.generator.service;
 
+import static org.folio.app.generator.utils.PluginUtils.collectToBulletedList;
 import static org.folio.app.generator.utils.PluginUtils.createModuleDefinitionFromId;
 
 import java.util.ArrayList;
@@ -8,7 +9,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.folio.app.generator.model.ModuleDefinition;
@@ -52,7 +52,7 @@ public class ModuleDescriptorService {
     notFoundModuleIds.removeAll(foundDescriptors.keySet());
 
     if (!notFoundModuleIds.isEmpty()) {
-      var modulesString = notFoundModuleIds.stream().collect(Collectors.joining("\n  * ", "\n  * ", ""));
+      var modulesString = collectToBulletedList(notFoundModuleIds);
       throw new MojoExecutionException("Failed to load module descriptors: " + modulesString);
     }
 

--- a/src/main/java/org/folio/app/generator/service/ModuleRegistryProvider.java
+++ b/src/main/java/org/folio/app/generator/service/ModuleRegistryProvider.java
@@ -1,11 +1,12 @@
 package org.folio.app.generator.service;
 
 import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.removeEnd;
 import static org.apache.commons.lang3.StringUtils.removeStart;
 import static org.apache.commons.lang3.StringUtils.trim;
+import static org.folio.app.generator.utils.PluginUtils.PATH_DELIMITER;
+import static org.folio.app.generator.utils.PluginUtils.collectToBulletedList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -86,7 +87,7 @@ public class ModuleRegistryProvider {
 
   private static void handleInvalidRegistries(List<String> invalidRegistries) throws MojoExecutionException {
     if (!invalidRegistries.isEmpty()) {
-      var invalidRegistryString = invalidRegistries.stream().collect(joining("\n  * ", "\n  * ", ""));
+      var invalidRegistryString = collectToBulletedList(invalidRegistries);
       throw new MojoExecutionException("Invalid registries found, "
         + "check documentation at README.md and provided registry list:" + invalidRegistryString);
     }
@@ -94,14 +95,15 @@ public class ModuleRegistryProvider {
 
   private static ModuleRegistry toModuleRegistry(ConfigModuleRegistry registry) {
     if ("s3".equals(registry.getType())) {
+      var path = removeEnd(removeStart(trim(registry.getPath()), PATH_DELIMITER), PATH_DELIMITER);
       return new S3ModuleRegistry()
-        .path(removeEnd(removeStart(trim(registry.getPath()), "/"), "/"))
+        .path(path.isEmpty() ? path : path + PATH_DELIMITER)
         .bucket(trim(registry.getBucket()))
         .publicUrl(trim(registry.getPublicUrlTemplate()));
     }
 
     return new OkapiModuleRegistry()
-      .url(removeEnd(trim(registry.getUrl()), "/"))
+      .url(removeEnd(trim(registry.getUrl()), PATH_DELIMITER))
       .publicUrl(trim(registry.getPublicUrlTemplate()));
   }
 }

--- a/src/main/java/org/folio/app/generator/service/loader/S3ModuleDescriptorLoader.java
+++ b/src/main/java/org/folio/app/generator/service/loader/S3ModuleDescriptorLoader.java
@@ -1,5 +1,6 @@
 package org.folio.app.generator.service.loader;
 
+import static java.lang.Boolean.TRUE;
 import static java.util.Optional.ofNullable;
 import static org.folio.app.generator.utils.PluginUtils.createModuleDefinitionFromId;
 
@@ -16,6 +17,7 @@ import org.folio.app.generator.model.registry.S3ModuleRegistry;
 import org.folio.app.generator.model.types.RegistryType;
 import org.folio.app.generator.utils.JsonConverter;
 import org.folio.app.generator.utils.PluginConfig;
+import org.folio.app.generator.utils.PluginUtils;
 import org.semver4j.Semver;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -42,7 +44,7 @@ public class S3ModuleDescriptorLoader implements ModuleDescriptorLoader {
     var version = module.getVersion();
     var filter = "latest".equals(version) ? module.getName() : module.getId();
     var s3RegistryPath = s3Registry.getPath();
-    var pathPrefix = s3RegistryPath.isEmpty() ? s3RegistryPath : s3RegistryPath + "/";
+    var pathPrefix = s3RegistryPath.isEmpty() ? s3RegistryPath : s3RegistryPath + PluginUtils.PATH_DELIMITER;
     var fullPrefix = pathPrefix + filter;
 
     return findLatestVersionByPrefix(s3Registry, pathPrefix, fullPrefix)
@@ -75,7 +77,7 @@ public class S3ModuleDescriptorLoader implements ModuleDescriptorLoader {
       }
 
       request = buildListObjectsRequest(s3Registry, prefix, result.nextContinuationToken());
-    } while (result.isTruncated());
+    } while (TRUE.equals(result.isTruncated()));
 
     return ofNullable(maxValueHolder).map(Pair::getRight);
   }

--- a/src/main/java/org/folio/app/generator/utils/PluginUtils.java
+++ b/src/main/java/org/folio/app/generator/utils/PluginUtils.java
@@ -1,14 +1,32 @@
 package org.folio.app.generator.utils;
 
+import static java.util.stream.Collectors.joining;
+
+import java.util.Collection;
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.app.generator.model.ModuleDefinition;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PluginUtils {
 
+  public static final String PATH_DELIMITER = "/";
+
+  /**
+   * Creates a {@link ModuleDefinition} object from the given module id.
+   *
+   * <p>This method splits module id to the module name and module version</p>
+   *
+   * @param moduleId - module id to be parsed
+   * @return {@link Optional} with {@link ModuleDefinition} object if module id parsed successfully, empty - otherwise
+   */
   public static Optional<ModuleDefinition> createModuleDefinitionFromId(String moduleId) {
+    if (StringUtils.isBlank(moduleId)) {
+      return Optional.empty();
+    }
+
     for (int i = 0; i < moduleId.length() - 1; i++) {
       if (moduleId.charAt(i) == '-' && Character.isDigit(moduleId.charAt(i + 1))) {
         return Optional.of(new ModuleDefinition()
@@ -19,5 +37,26 @@ public class PluginUtils {
     }
 
     return Optional.empty();
+  }
+
+  /**
+   * Collects values and represents them as a bulleted list after error.
+   *
+   * <p>Example of response of joining this value to an error message:</p>
+   * <pre>
+   *   Invalid values found:
+   *     * value1
+   *     * value2
+   * </pre>
+   *
+   * @param values - list of values to process
+   * @return bulleted list as {@link String} object
+   */
+  public static String collectToBulletedList(Collection<String> values) {
+    if (values == null || values.isEmpty()) {
+      return "";
+    }
+
+    return values.stream().collect(joining("\n  * ", "\n  * ", ""));
   }
 }

--- a/src/test/java/org/folio/app/generator/service/parsers/StringModuleRegistryParserTest.java
+++ b/src/test/java/org/folio/app/generator/service/parsers/StringModuleRegistryParserTest.java
@@ -58,14 +58,14 @@ class StringModuleRegistryParserTest {
         okapiModuleRegistry("https://test-okapi.sample", "https://test-host.sample/okapi/${id}")),
 
       arguments("s3::test-bucket::/", s3ModuleRegistry("test-bucket", "")),
-      arguments("s3::test-bucket::test", s3ModuleRegistry("test-bucket", "test")),
-      arguments("s3::test-bucket::/test", s3ModuleRegistry("test-bucket", "test")),
-      arguments("s3::  test-bucket  ::  /test", s3ModuleRegistry("test-bucket", "test")),
-      arguments("s3::foo-bucket::/foo/bar", s3ModuleRegistry("foo-bucket", "foo/bar")),
-      arguments("s3::foo-bucket::/foo/bar/", s3ModuleRegistry("foo-bucket", "foo/bar")),
+      arguments("s3::test-bucket::test", s3ModuleRegistry("test-bucket", "test/")),
+      arguments("s3::test-bucket::/test", s3ModuleRegistry("test-bucket", "test/")),
+      arguments("s3::  test-bucket  ::  /test", s3ModuleRegistry("test-bucket", "test/")),
+      arguments("s3::foo-bucket::/foo/bar", s3ModuleRegistry("foo-bucket", "foo/bar/")),
+      arguments("s3::foo-bucket::/foo/bar/", s3ModuleRegistry("foo-bucket", "foo/bar/")),
 
       arguments("s3::test-bucket::/foo/bar/::https://s3-alias.sample/${id}",
-        s3ModuleRegistry("test-bucket", "foo/bar", "https://s3-alias.sample/${id}"))
+        s3ModuleRegistry("test-bucket", "foo/bar/", "https://s3-alias.sample/${id}"))
     );
   }
 


### PR DESCRIPTION
## Purpose

Refactors the code to reduce the number of sonarcloud code smells

## Approach

- [Remove this field injection and use constructor injection instead.](https://sonarcloud.io/project/issues?open=AY4YkkcjEDDgBkVwZn3h&id=org.folio%3Afolio-application-generator)
- [Remove this field injection and use constructor injection instead.](https://sonarcloud.io/project/issues?open=AY4YkkcjEDDgBkVwZn3i&id=org.folio%3Afolio-application-generator)
- [Rename field "applicationDescriptorGenerator"](https://sonarcloud.io/project/issues?open=AY4YkkcTEDDgBkVwZn3f&id=org.folio%3Afolio-application-generator)
- [Remove the declaration of thrown exception 'org.apache.maven.plugin.MojoExecutionException', as it cannot be thrown from method's body.](https://sonarcloud.io/project/issues?open=AY4YkkbjEDDgBkVwZn3b&id=org.folio%3Afolio-application-generator)
- [Remove this hard-coded path-delimiter.](https://sonarcloud.io/project/issues?open=AY4YkkcGEDDgBkVwZn3d&id=org.folio%3Afolio-application-generator)
- [Use a primitive boolean expression for do-while cycle in S3ModuleRegistryLoader.](https://sonarcloud.io/project/issues?open=AY4YkkcGEDDgBkVwZn3c&id=org.folio%3Afolio-application-generator)
- [Reduce the total number of break and continue statements in ApplicationDependencyValidator.java.](https://sonarcloud.io/project/issues?open=AY4YkkccEDDgBkVwZn3g&id=org.folio%3Afolio-application-generator)

