### PR TITLE
APPDESCRIP-13 Add an ability to load module descriptors separately

### DIFF
--- a/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
+++ b/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
@@ -7,7 +7,6 @@ import java.util.List;
 import javax.inject.Inject;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.folio.app.generator.configuration.ApplicationContextBuilder;
@@ -31,11 +30,23 @@ public abstract class AbstractGeneratorMojo extends AbstractMojo {
   @Parameter(defaultValue = "${registries}")
   protected String cmdRegistriesString;
 
+  @Parameter(defaultValue = "${beRegistries}")
+  protected String cmdBeRegistriesString;
+
+  @Parameter(defaultValue = "${uiRegistries}")
+  protected String cmdUiRegistriesString;
+
   @Parameter(defaultValue = "${overrideConfigRegistries}")
   protected String overrideConfigRegistries;
 
   @Parameter(name = "moduleRegistries")
   protected List<ConfigModuleRegistry> moduleRegistries;
+
+  @Parameter(name = "beModuleRegistries")
+  protected List<ConfigModuleRegistry> beModuleRegistries;
+
+  @Parameter(name = "uiModuleRegistries")
+  protected List<ConfigModuleRegistry> uiModuleRegistries;
 
   @Parameter(name = "useModuleDescriptorsUrls")
   protected String useModuleDescriptorsUrls;
@@ -52,17 +63,21 @@ public abstract class AbstractGeneratorMojo extends AbstractMojo {
     this.applicationContextBuilder = contextBuilder;
   }
 
-  protected GenericApplicationContext buildApplicationContext() throws MojoExecutionException {
+  protected GenericApplicationContext buildApplicationContext() {
     var pluginConfig = PluginConfig.builder()
       .buildNumber(buildNumber)
       .registries(moduleRegistries)
+      .uiRegistries(uiModuleRegistries)
+      .beRegistries(beModuleRegistries)
       .cmdRegistryString(cmdRegistriesString)
+      .beCmdRegistryString(cmdBeRegistriesString)
+      .uiCmdRegistryString(cmdUiRegistriesString)
       .overrideConfigRegistries(parseBoolean(overrideConfigRegistries))
       .useModuleDescriptorsUrls(parseBoolean(useModuleDescriptorsUrls))
       .awsRegion(isNotBlank(awsRegion) ? Region.of(awsRegion) : Region.US_EAST_1)
       .build();
 
-    var registries = moduleRegistryProvider.validateAndGetModuleRegistries(pluginConfig);
+    var registries = moduleRegistryProvider.getModuleRegistries(pluginConfig);
 
     return applicationContextBuilder
       .withLog(getLog())

--- a/src/main/java/org/folio/app/generator/model/registry/ConfigModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/ConfigModuleRegistry.java
@@ -1,6 +1,7 @@
 package org.folio.app.generator.model.registry;
 
 import lombok.Data;
+import lombok.ToString;
 
 @Data
 public class ConfigModuleRegistry {
@@ -13,6 +14,7 @@ public class ConfigModuleRegistry {
   /**
    * Public url template, where module id must have {@code {id}} placeholder.
    */
+  @ToString.Exclude
   private String publicUrlTemplate;
 
   /**

--- a/src/main/java/org/folio/app/generator/model/registry/ModuleRegistries.java
+++ b/src/main/java/org/folio/app/generator/model/registry/ModuleRegistries.java
@@ -1,5 +1,11 @@
 package org.folio.app.generator.model.registry;
 
 import java.util.List;
+import org.folio.app.generator.model.types.ModuleType;
 
-public record ModuleRegistries(List<ModuleRegistry> registries) {}
+public record ModuleRegistries(List<ModuleRegistry> beRegistries, List<ModuleRegistry> uiRegistries) {
+
+  public List<ModuleRegistry> getRegistries(ModuleType type) {
+    return type == ModuleType.BE ? beRegistries : uiRegistries;
+  }
+}

--- a/src/main/java/org/folio/app/generator/model/registry/S3ModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/S3ModuleRegistry.java
@@ -56,9 +56,9 @@ public class S3ModuleRegistry implements ModuleRegistry {
   @Override
   public S3ModuleRegistry withGeneratedFields() {
     if (isBlank(this.publicUrl)) {
-      this.publicUrl = path.isEmpty()
+      this.publicUrl = StringUtils.isEmpty(path)
         ? String.format("https://%s.s3.amazonaws.com/{id}", bucket)
-        : String.format("https://%s.s3.amazonaws.com/%s/{id}", bucket, path);
+        : String.format("https://%s.s3.amazonaws.com/%s{id}", bucket, path);
     }
 
     return this;

--- a/src/main/java/org/folio/app/generator/model/types/ModuleType.java
+++ b/src/main/java/org/folio/app/generator/model/types/ModuleType.java
@@ -1,0 +1,5 @@
+package org.folio.app.generator.model.types;
+
+public enum ModuleType {
+  BE, UI
+}

--- a/src/main/java/org/folio/app/generator/service/ApplicationDescriptorService.java
+++ b/src/main/java/org/folio/app/generator/service/ApplicationDescriptorService.java
@@ -1,7 +1,10 @@
 package org.folio.app.generator.service;
 
-import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.folio.app.generator.model.types.ModuleType.BE;
+import static org.folio.app.generator.model.types.ModuleType.UI;
+import static org.folio.app.generator.utils.PluginUtils.emptyIfNull;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -35,8 +38,8 @@ public class ApplicationDescriptorService {
 
     var modules = convertToArtifacts(template.getModules());
     var uiModules = convertToArtifacts(template.getUiModules());
-    var modulesLoadResult = moduleDescriptorService.loadModules(modules);
-    var uiModulesLoadResult = moduleDescriptorService.loadModules(uiModules);
+    var modulesLoadResult = moduleDescriptorService.loadModules(BE, modules);
+    var uiModulesLoadResult = moduleDescriptorService.loadModules(UI, uiModules);
 
     return baseAppDescriptor
       .description(defaultIfBlank(template.getDescription(), mavenProject.getDescription()))
@@ -87,14 +90,6 @@ public class ApplicationDescriptorService {
     var name = dependency.getName();
     var version = dependency.getVersion();
     return new ModuleDefinition().id(name + "-" + version).name(name).version(version);
-  }
-
-  public static <T> List<T> emptyIfNull(List<T> list) {
-    return list == null ? emptyList() : list;
-  }
-
-  public static String defaultIfBlank(String value, String defaultValue) {
-    return value == null || value.isBlank() ? defaultValue : value;
   }
 
   private String getVersionWithBuildNumber(String version) {

--- a/src/main/java/org/folio/app/generator/service/ModuleRegistryProvider.java
+++ b/src/main/java/org/folio/app/generator/service/ModuleRegistryProvider.java
@@ -1,7 +1,9 @@
 package org.folio.app.generator.service;
 
 import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.lowerCase;
 import static org.apache.commons.lang3.StringUtils.removeEnd;
 import static org.apache.commons.lang3.StringUtils.removeStart;
 import static org.apache.commons.lang3.StringUtils.trim;
@@ -9,11 +11,15 @@ import static org.folio.app.generator.utils.PluginUtils.PATH_DELIMITER;
 import static org.folio.app.generator.utils.PluginUtils.collectToBulletedList;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import javax.inject.Inject;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.app.generator.model.registry.ConfigModuleRegistry;
+import org.folio.app.generator.model.registry.ModuleRegistries;
 import org.folio.app.generator.model.registry.ModuleRegistry;
 import org.folio.app.generator.model.registry.OkapiModuleRegistry;
 import org.folio.app.generator.model.registry.S3ModuleRegistry;
@@ -29,75 +35,72 @@ public class ModuleRegistryProvider {
   /**
    * Provides list of validated registries to load module descriptors.
    *
-   * @param pluginConfig -  initial plugin configuration as {@link PluginConfig} object
+   * @param config -  initial plugin configuration as {@link PluginConfig} object
    * @return {@link List} with {@link ModuleRegistry} objects
-   * @throws MojoExecutionException for any errors found during registry list validations
    */
-  public List<ModuleRegistry> validateAndGetModuleRegistries(PluginConfig pluginConfig) throws MojoExecutionException {
-    var cmdRegistryString = pluginConfig.getCmdRegistryString();
-    var invalidRegistries = new ArrayList<String>();
-    var commandLineRegistries = getCommandLineRegistries(cmdRegistryString, invalidRegistries);
-
-    if (pluginConfig.isOverrideConfigRegistries() && !commandLineRegistries.isEmpty()) {
-      handleInvalidRegistries(invalidRegistries);
-      return commandLineRegistries;
-    }
-
-    var resultModuleRegistries = new ArrayList<>(commandLineRegistries);
-    resultModuleRegistries.addAll(validateAndGetConfigRegistries(pluginConfig, invalidRegistries));
-    handleInvalidRegistries(invalidRegistries);
-    return resultModuleRegistries;
+  public ModuleRegistries getModuleRegistries(PluginConfig config) {
+    var processor = new ModuleRegistryProcessor(config);
+    handleInvalidRegistries(processor.getInvalidRegistries());
+    return new ModuleRegistries(processor.getBeRegistries(), processor.getUiRegistries());
   }
 
-  private List<ModuleRegistry> getCommandLineRegistries(String cmdRegistryString, ArrayList<String> invalidRegistries) {
-    if (isBlank(cmdRegistryString)) {
-      return emptyList();
+  private ModuleRegistryProcessingResult processCommandLineRegistries(String registryString) {
+    if (isBlank(registryString)) {
+      return new ModuleRegistryProcessingResult(emptyList(), emptyList());
     }
 
+    var invalidRegistries = new ArrayList<String>();
     var commandLineRegistries = new ArrayList<ModuleRegistry>();
-    var moduleRegistryStrings = cmdRegistryString.split(",");
+    var moduleRegistryStrings = registryString.split(",");
 
     for (var value : moduleRegistryStrings) {
       var moduleRegistry = moduleRegistryParser.parse(value);
-      moduleRegistry.ifPresentOrElse(commandLineRegistries::add, () -> invalidRegistries.add(value));
+      moduleRegistry.ifPresentOrElse(commandLineRegistries::add, () ->
+        invalidRegistries.add(String.format("CommandLineRegistry(stringValue=%s)", value)));
     }
 
-    return commandLineRegistries;
+    return new ModuleRegistryProcessingResult(commandLineRegistries, invalidRegistries);
   }
 
-  private List<ModuleRegistry> validateAndGetConfigRegistries(PluginConfig config, List<String> invalidRegistryList) {
+  private ModuleRegistryProcessingResult processConfigurationRegistries(List<ConfigModuleRegistry> registries) {
+    if (registries == null || registries.isEmpty()) {
+      return new ModuleRegistryProcessingResult(emptyList(), emptyList());
+    }
+
+    var invalidRegistries = new ArrayList<String>();
     var result = new ArrayList<ModuleRegistry>();
-    for (var configRegistry : config.getRegistries()) {
-      if (!supportedRegistryTypes.contains(configRegistry.getType())) {
-        invalidRegistryList.add(configRegistry.toString());
+    for (var configRegistry : registries) {
+      if (!supportedRegistryTypes.contains(lowerCase(configRegistry.getType()))) {
+        invalidRegistries.add(configRegistry.toString());
         continue;
       }
 
       var registry = toModuleRegistry(configRegistry);
 
       if (!registry.isValid()) {
-        invalidRegistryList.add(configRegistry.toString());
+        invalidRegistries.add(configRegistry.toString());
+      } else {
+        result.add(registry.withGeneratedFields());
       }
-
-      result.add(registry.withGeneratedFields());
     }
 
-    return result;
+    return new ModuleRegistryProcessingResult(result, invalidRegistries);
   }
 
-  private static void handleInvalidRegistries(List<String> invalidRegistries) throws MojoExecutionException {
+  private static void handleInvalidRegistries(List<String> invalidRegistries) {
     if (!invalidRegistries.isEmpty()) {
       var invalidRegistryString = collectToBulletedList(invalidRegistries);
-      throw new MojoExecutionException("Invalid registries found, "
+      throw new IllegalArgumentException("Invalid registries found, "
         + "check documentation at README.md and provided registry list:" + invalidRegistryString);
     }
   }
 
   private static ModuleRegistry toModuleRegistry(ConfigModuleRegistry registry) {
     if ("s3".equals(registry.getType())) {
-      var path = removeEnd(removeStart(trim(registry.getPath()), PATH_DELIMITER), PATH_DELIMITER);
+      var path = defaultIfBlank(registry.getPath(), "");
+      path = removeEnd(removeStart(path, PATH_DELIMITER), PATH_DELIMITER);
       return new S3ModuleRegistry()
-        .path(path.isEmpty() ? path : path + PATH_DELIMITER)
+        .path(StringUtils.isEmpty(path) ? path : path + PATH_DELIMITER)
         .bucket(trim(registry.getBucket()))
         .publicUrl(trim(registry.getPublicUrlTemplate()));
     }
@@ -106,4 +109,55 @@ public class ModuleRegistryProvider {
       .url(removeEnd(trim(registry.getUrl()), PATH_DELIMITER))
       .publicUrl(trim(registry.getPublicUrlTemplate()));
   }
+
+  @SafeVarargs
+  private static <T> List<T> merge(Collection<T>... collections) {
+    return Arrays.stream(collections)
+      .flatMap(Collection::stream)
+      .toList();
+  }
+
+  private final class ModuleRegistryProcessor {
+
+    @Getter private final List<String> invalidRegistries;
+    @Getter private final List<ModuleRegistry> beRegistries;
+    @Getter private final List<ModuleRegistry> uiRegistries;
+
+    private final PluginConfig pluginConfig;
+    private final List<ModuleRegistry> registries;
+    private final List<ModuleRegistry> cmdRegistries;
+
+    ModuleRegistryProcessor(PluginConfig config) {
+      this.pluginConfig = config;
+      this.invalidRegistries = new ArrayList<>();
+
+      var registriesProcessingResult = processConfigurationRegistries(config.getRegistries());
+      var cmdRegistriesProcessingResult = processCommandLineRegistries(config.getCmdRegistryString());
+
+      this.invalidRegistries.addAll(cmdRegistriesProcessingResult.invalidRegistries());
+      this.invalidRegistries.addAll(registriesProcessingResult.invalidRegistries());
+
+      this.registries = registriesProcessingResult.registries();
+      this.cmdRegistries = cmdRegistriesProcessingResult.registries();
+
+      this.beRegistries = processModuleRegistries(config.getBeCmdRegistryString(), config.getBeRegistries());
+      this.uiRegistries = processModuleRegistries(config.getUiCmdRegistryString(), config.getUiRegistries());
+    }
+
+    private List<ModuleRegistry> processModuleRegistries(String registryStr,
+      List<ConfigModuleRegistry> moduleRegistries) {
+      var cmdRegistriesResultForType = processCommandLineRegistries(registryStr);
+      invalidRegistries.addAll(cmdRegistriesResultForType.invalidRegistries());
+      var cmdRegistriesForType = cmdRegistriesResultForType.registries();
+      if (pluginConfig.isOverrideConfigRegistries()) {
+        return merge(cmdRegistriesForType, cmdRegistries);
+      }
+
+      var registriesResultForType = processConfigurationRegistries(moduleRegistries);
+      invalidRegistries.addAll(cmdRegistriesResultForType.invalidRegistries());
+      return merge(cmdRegistriesForType, cmdRegistries, registriesResultForType.registries(), registries);
+    }
+  }
+
+  private record ModuleRegistryProcessingResult(List<ModuleRegistry> registries, List<String> invalidRegistries) {}
 }

--- a/src/main/java/org/folio/app/generator/service/loader/ModuleDescriptorLoaderFacade.java
+++ b/src/main/java/org/folio/app/generator/service/loader/ModuleDescriptorLoaderFacade.java
@@ -25,6 +25,13 @@ public class ModuleDescriptorLoaderFacade {
     this.loadersMap = loaders.stream().collect(toMap(ModuleDescriptorLoader::getType, identity()));
   }
 
+  /**
+   * Tries to find module descriptor in specified registry using {@link ModuleDefinition} object.
+   *
+   * @param registry - {@link ModuleRegistry} description
+   * @param module - {@link ModuleDefinition} object with required information to find a module
+   * @return {@link Optional} of {@link Map} as module descriptor
+   */
   public Optional<Map<String, Object>> find(ModuleRegistry registry, ModuleDefinition module) {
     var moduleDescriptorLoader = loadersMap.get(registry.getType());
     if (moduleDescriptorLoader == null) {

--- a/src/main/java/org/folio/app/generator/service/parsers/StringModuleRegistryParser.java
+++ b/src/main/java/org/folio/app/generator/service/parsers/StringModuleRegistryParser.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.app.generator.model.registry.ModuleRegistry;
 import org.folio.app.generator.model.registry.OkapiModuleRegistry;
@@ -33,18 +34,24 @@ public class StringModuleRegistryParser {
   /**
    * Parses module registry string to a {@link ModuleRegistry} object.
    *
-   * @param sourceValue - {@link String} value to parse.
+   * @param registryString - {@link String} value to parse.
    * @return {@link Optional} of {@link ModuleRegistry} object, it will be null if source string is not compatible
    */
-  public Optional<ModuleRegistry> parse(String sourceValue) {
+  public Optional<ModuleRegistry> parse(String registryString) {
+    if (StringUtils.isBlank(registryString)) {
+      return Optional.empty();
+    }
+
+    var value = registryString.trim();
     for (var patternPair : patterns) {
       var pattern = patternPair.getLeft();
-      var matcher = pattern.matcher(sourceValue);
+      var matcher = pattern.matcher(value);
       if (matcher.matches()) {
         var stringParts = convertToStringPartsArray(matcher);
         return Optional.of(patternPair.getRight().apply(stringParts));
       }
     }
+
     return Optional.empty();
   }
 

--- a/src/main/java/org/folio/app/generator/utils/PluginConfig.java
+++ b/src/main/java/org/folio/app/generator/utils/PluginConfig.java
@@ -12,9 +12,15 @@ import software.amazon.awssdk.regions.Region;
 public class PluginConfig {
 
   private final String buildNumber;
+
   private final List<ConfigModuleRegistry> registries;
+  private final List<ConfigModuleRegistry> beRegistries;
+  private final List<ConfigModuleRegistry> uiRegistries;
 
   private final String cmdRegistryString;
+  private final String beCmdRegistryString;
+  private final String uiCmdRegistryString;
+
   private final boolean useModuleDescriptorsUrls;
   private final boolean overrideConfigRegistries;
 

--- a/src/main/java/org/folio/app/generator/utils/PluginUtils.java
+++ b/src/main/java/org/folio/app/generator/utils/PluginUtils.java
@@ -1,8 +1,11 @@
 package org.folio.app.generator.utils;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -58,5 +61,26 @@ public class PluginUtils {
     }
 
     return values.stream().collect(joining("\n  * ", "\n  * ", ""));
+  }
+
+  /**
+   * Returns empty unmodifiable list if provided value is null.
+   *
+   * @param value - {@link List} value to check
+   * @param <T> - generic type for list element
+   * @return {@link Collections#emptyList()} if provided value is null
+   */
+  public static <T> List<T> emptyIfNull(List<T> value) {
+    return value == null ? emptyList() : value;
+  }
+
+  /**
+   * Checks if collection is null or empty.
+   *
+   * @param collection - {@link Collection} object to check
+   * @return true if collection is null or empty, false - otherwise
+   */
+  public static boolean isEmpty(Collection<?> collection) {
+    return collection == null || collection.isEmpty();
   }
 }

--- a/src/test/java/org/folio/app/generator/service/ModuleRegistryProviderTest.java
+++ b/src/test/java/org/folio/app/generator/service/ModuleRegistryProviderTest.java
@@ -1,0 +1,263 @@
+package org.folio.app.generator.service;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.folio.app.generator.model.registry.ConfigModuleRegistry;
+import org.folio.app.generator.model.registry.ModuleRegistries;
+import org.folio.app.generator.model.registry.ModuleRegistry;
+import org.folio.app.generator.model.registry.OkapiModuleRegistry;
+import org.folio.app.generator.model.registry.S3ModuleRegistry;
+import org.folio.app.generator.service.parsers.StringModuleRegistryParser;
+import org.folio.app.generator.support.UnitTest;
+import org.folio.app.generator.utils.PluginConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@UnitTest
+class ModuleRegistryProviderTest {
+
+  private ModuleRegistryProvider moduleRegistryProvider;
+
+  @BeforeEach
+  void setUp() {
+    this.moduleRegistryProvider = new ModuleRegistryProvider(new StringModuleRegistryParser());
+  }
+
+  @MethodSource("pluginConfigProvider")
+  @ParameterizedTest(name = "[{index}] {0}")
+  void getModuleRegistries_positive_parameterized(@SuppressWarnings("unused") String name,
+    PluginConfig config, ModuleRegistries expected) {
+    var result = moduleRegistryProvider.getModuleRegistries(config);
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void getModuleRegistries_negative_unsupportedType() {
+    var config = PluginConfig.builder().registries(List.of(unknownModuleRegistry())).build();
+
+    assertThatThrownBy(() -> moduleRegistryProvider.getModuleRegistries(config))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("""
+        Invalid registries found, check documentation at README.md and provided registry list:
+          * ConfigModuleRegistry(type=unknown, url=https://localhost:8000/registry, path=null, bucket=null)""");
+  }
+
+  @Test
+  void getModuleRegistries_negative_invalidCommandLineRegistry() {
+    var config = PluginConfig.builder().cmdRegistryString("unknown::test").build();
+
+    assertThatThrownBy(() -> moduleRegistryProvider.getModuleRegistries(config))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("""
+        Invalid registries found, check documentation at README.md and provided registry list:
+          * CommandLineRegistry(stringValue=unknown::test)""");
+  }
+
+  @Test
+  void getModuleRegistries_negative_invalidUrl() {
+    var config = PluginConfig.builder().registries(List.of(okapiConfigRegistry("unknown-url"))).build();
+
+    assertThatThrownBy(() -> moduleRegistryProvider.getModuleRegistries(config))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("""
+        Invalid registries found, check documentation at README.md and provided registry list:
+          * ConfigModuleRegistry(type=okapi, url=unknown-url, path=null, bucket=null)""");
+  }
+
+  @Test
+  void getModuleRegistries_negative_nullBucketPath() {
+    var registry = new ConfigModuleRegistry();
+    registry.setType("s3");
+    var config = PluginConfig.builder().registries(List.of(registry)).build();
+
+    assertThatThrownBy(() -> moduleRegistryProvider.getModuleRegistries(config))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("""
+        Invalid registries found, check documentation at README.md and provided registry list:
+          * ConfigModuleRegistry(type=s3, url=null, path=null, bucket=null)""");
+  }
+
+  private static Stream<Arguments> pluginConfigProvider() {
+    return Stream.of(
+      arguments(
+        "Config registry provided (override = false)",
+        config(false, null, okapiConfigRegistry()),
+        registries(List.of(okapiRegistry()), List.of(okapiRegistry()))),
+
+      arguments(
+        "Config registry (s3 with null path) provided (override = false)",
+        config(false, null, s3ConfigRegistry(null)),
+        registries(List.of(s3Registry("")), List.of(s3Registry("")))),
+
+      arguments(
+        "Config registry provided (override = true)",
+        config(true, null, okapiConfigRegistry()),
+        registries(emptyList(), emptyList())),
+
+      arguments(
+        "Command-line(s3) and config(okapi) registries provided (override = false)",
+        config(false, "s3::test::/", okapiConfigRegistry()),
+        registries(List.of(s3Registry(""), okapiRegistry()), List.of(s3Registry(""), okapiRegistry()))),
+
+      arguments(
+        "Command-line(s3) and config(okapi) registries provided (override = true)",
+        config(true, "s3::test::test/", okapiConfigRegistry()),
+        registries(List.of(s3Registry()), List.of(s3Registry()))),
+
+      arguments(
+        "Command-line(okapi) and config(s3) registries provided (override = false)",
+        config(false, "okapi::https://localhost:9130", s3ConfigRegistry()),
+        registries(List.of(okapiRegistry(), s3Registry()), List.of(okapiRegistry(), s3Registry()))),
+
+      arguments(
+        "Command-line(okapi) and config(s3) registries provided (override = true)",
+        config(true, "okapi::https://localhost:9130", s3ConfigRegistry()),
+        registries(List.of(okapiRegistry()), List.of(okapiRegistry()))),
+
+      arguments("Config (be, ui) registries provided (override = false)",
+        PluginConfig.builder()
+          .overrideConfigRegistries(false)
+          .beRegistries(List.of(s3ConfigRegistry("be/")))
+          .uiRegistries(List.of(s3ConfigRegistry("ui/")))
+          .build(),
+        registries(List.of(s3Registry("be/")), List.of(s3Registry("ui/")))),
+
+      arguments("Config (be, ui, global) registries provided (override = false)",
+        PluginConfig.builder()
+          .overrideConfigRegistries(false)
+          .registries(List.of(okapiConfigRegistry()))
+          .beRegistries(List.of(s3ConfigRegistry("be/")))
+          .uiRegistries(List.of(s3ConfigRegistry("ui/")))
+          .build(),
+        registries(List.of(s3Registry("be/"), okapiRegistry()), List.of(s3Registry("ui/"), okapiRegistry()))),
+
+      arguments("Command-line(be, ui) and config (be, ui) registries provided (override = false)",
+        PluginConfig.builder()
+          .overrideConfigRegistries(false)
+          .beRegistries(List.of(s3ConfigRegistry("be/")))
+          .uiRegistries(List.of(s3ConfigRegistry("ui/")))
+          .beCmdRegistryString("s3::test::be/f/")
+          .uiCmdRegistryString("s3::test::ui/f/")
+          .build(),
+        registries(List.of(s3Registry("be/f/"), s3Registry("be/")), List.of(s3Registry("ui/f/"), s3Registry("ui/")))),
+
+      arguments("Command-line(be) and config (ui) registries provided (override = false)",
+        PluginConfig.builder()
+          .overrideConfigRegistries(false)
+          .beCmdRegistryString("s3::test::be/f/")
+          .uiRegistries(List.of(s3ConfigRegistry("ui/")))
+          .build(),
+        registries(List.of(s3Registry("be/f/")), List.of(s3Registry("ui/")))),
+
+      arguments("Command-line(be, ui) and config (be, ui) registries provided (override = true)",
+        PluginConfig.builder()
+          .registries(emptyList())
+          .overrideConfigRegistries(true)
+          .beRegistries(List.of(s3ConfigRegistry("be/")))
+          .uiRegistries(List.of(s3ConfigRegistry("ui/")))
+          .beCmdRegistryString("s3::test::be/f/")
+          .uiCmdRegistryString("s3::test::ui/f/")
+          .build(),
+        registries(List.of(s3Registry("be/f/")), List.of(s3Registry("ui/f/")))),
+
+      arguments("Command-line(be, ui, global) and config (be, ui, global) registries provided (override = false)",
+        PluginConfig.builder()
+          .overrideConfigRegistries(false)
+          .registries(List.of(okapiConfigRegistry()))
+          .beRegistries(List.of(s3ConfigRegistry("be/")))
+          .uiRegistries(List.of(s3ConfigRegistry("ui/")))
+          .cmdRegistryString("s3::test::/global/")
+          .beCmdRegistryString("s3::test::be/f/")
+          .uiCmdRegistryString("s3::test::ui/f/")
+          .build(),
+        registries(
+          List.of(s3Registry("be/f/"), s3Registry("global/"), s3Registry("be/"), okapiRegistry()),
+          List.of(s3Registry("ui/f/"), s3Registry("global/"), s3Registry("ui/"), okapiRegistry()))),
+
+      arguments("Config (be, ui, global) registries provided (override = false)",
+        PluginConfig.builder()
+          .overrideConfigRegistries(false)
+          .registries(List.of(okapiConfigRegistry()))
+          .beRegistries(List.of(s3ConfigRegistry("be/")))
+          .uiRegistries(List.of(s3ConfigRegistry("ui/")))
+          .build(),
+        registries(List.of(s3Registry("be/"), okapiRegistry()), List.of(s3Registry("ui/"), okapiRegistry()))),
+
+      arguments("Config (be, ui, global) registries provided (override = true)",
+        PluginConfig.builder()
+          .overrideConfigRegistries(true)
+          .registries(List.of(okapiConfigRegistry()))
+          .beRegistries(List.of(s3ConfigRegistry("be/")))
+          .uiRegistries(List.of(s3ConfigRegistry("ui/")))
+          .build(),
+        registries(emptyList(), emptyList()))
+    );
+  }
+
+  private static ModuleRegistries registries(List<ModuleRegistry> beRegistries, List<ModuleRegistry> uiRegistries) {
+    return new ModuleRegistries(beRegistries, uiRegistries);
+  }
+
+  private static PluginConfig config(boolean overrideRegistries, String cmdString, ConfigModuleRegistry... registries) {
+    return PluginConfig.builder()
+      .overrideConfigRegistries(overrideRegistries)
+      .registries(List.of(registries))
+      .cmdRegistryString(cmdString)
+      .build();
+  }
+
+  private static ConfigModuleRegistry unknownModuleRegistry() {
+    var configModuleRegistry = new ConfigModuleRegistry();
+    configModuleRegistry.setType("unknown");
+    configModuleRegistry.setUrl("https://localhost:8000/registry");
+    return configModuleRegistry;
+  }
+
+  private static ModuleRegistry okapiRegistry() {
+    return new OkapiModuleRegistry()
+      .url("https://localhost:9130")
+      .withGeneratedFields();
+  }
+
+  private static ModuleRegistry s3Registry() {
+    return s3Registry("test/");
+  }
+
+  private static ModuleRegistry s3Registry(String path) {
+    return new S3ModuleRegistry()
+      .bucket("test")
+      .path(path)
+      .withGeneratedFields();
+  }
+
+  private static ConfigModuleRegistry okapiConfigRegistry() {
+    return okapiConfigRegistry("https://localhost:9130");
+  }
+
+  private static ConfigModuleRegistry okapiConfigRegistry(String url) {
+    var configModuleRegistry = new ConfigModuleRegistry();
+    configModuleRegistry.setType("okapi");
+    configModuleRegistry.setUrl(url);
+    return configModuleRegistry;
+  }
+
+  private static ConfigModuleRegistry s3ConfigRegistry() {
+    return s3ConfigRegistry("test/");
+  }
+
+  private static ConfigModuleRegistry s3ConfigRegistry(String path) {
+    var configModuleRegistry = new ConfigModuleRegistry();
+    configModuleRegistry.setType("s3");
+    configModuleRegistry.setBucket("test");
+    configModuleRegistry.setPath(path);
+    return configModuleRegistry;
+  }
+}

--- a/src/test/java/org/folio/app/generator/service/parsers/StringModuleRegistryParserTest.java
+++ b/src/test/java/org/folio/app/generator/service/parsers/StringModuleRegistryParserTest.java
@@ -43,12 +43,16 @@ class StringModuleRegistryParserTest {
 
   public static Stream<Arguments> registryStringDataSource() {
     return Stream.of(
+      arguments("", null),
+      arguments(null, null),
+      arguments("  ", null),
       arguments("http://localhost:3000", null),
       arguments("okapi::http://localhost:3000", okapiModuleRegistry("http://localhost:3000")),
       arguments("okapi::  http://localhost:3000", okapiModuleRegistry("http://localhost:3000")),
       arguments("okapi::http://localhost:3000/", okapiModuleRegistry("http://localhost:3000")),
       arguments("okapi::https://test-okapi.sample", okapiModuleRegistry("https://test-okapi.sample")),
       arguments("okapi::https://test-okapi.sample/", okapiModuleRegistry("https://test-okapi.sample")),
+      arguments("  okapi::http://localhost:3000  ", okapiModuleRegistry("http://localhost:3000")),
 
       arguments("okapi::http://localhost:3000::https://test-okapi.sample/${id}",
         okapiModuleRegistry("http://localhost:3000", "https://test-okapi.sample/${id}")),
@@ -74,24 +78,22 @@ class StringModuleRegistryParserTest {
   }
 
   private static Object okapiModuleRegistry(String url, String publicUrlTemplate) {
-    var registry = new OkapiModuleRegistry();
-    registry.setUrl(url);
-    registry.setPublicUrl(publicUrlTemplate);
-    return registry;
+    return new OkapiModuleRegistry()
+      .url(url)
+      .publicUrl(publicUrlTemplate);
   }
 
   private static S3ModuleRegistry s3ModuleRegistry(String bucket, String path) {
     var publicUrlTemplate = path.isEmpty()
       ? String.format("https://%s.s3.amazonaws.com/{id}", bucket)
-      : String.format("https://%s.s3.amazonaws.com/%s/{id}", bucket, path);
+      : String.format("https://%s.s3.amazonaws.com/%s{id}", bucket, path);
     return s3ModuleRegistry(bucket, path, publicUrlTemplate);
   }
 
   private static S3ModuleRegistry s3ModuleRegistry(String bucket, String path, String publicUrl) {
-    var registry = new S3ModuleRegistry();
-    registry.setBucket(bucket);
-    registry.setPath(path);
-    registry.setPublicUrl(publicUrl);
-    return registry;
+    return new S3ModuleRegistry()
+      .bucket(bucket)
+      .path(path)
+      .publicUrl(publicUrl);
   }
 }


### PR DESCRIPTION
## Purpose

Implements command-line/configuration parameters to provide registries for loading BE and UI modules separately

## Approach

- Implement an ability to specify registries for BE and UI modules
- Improve documentation
- Fix bugs (NPE if dependencies/ui-modules/modules are null)

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->
