### PR TITLE
APPDESCRIP-14 Fix an issue for loading modules from s3 bucket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,6 @@
     </dependency>
 
     <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>apache-client</artifactId>
-      <version>${aws-sdk.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>localstack</artifactId>
       <version>${testcontainers.version}</version>

--- a/src/main/java/org/folio/app/generator/service/loader/S3ModuleDescriptorLoader.java
+++ b/src/main/java/org/folio/app/generator/service/loader/S3ModuleDescriptorLoader.java
@@ -1,12 +1,14 @@
 package org.folio.app.generator.service.loader;
 
 import static java.lang.Boolean.TRUE;
+import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 import static org.folio.app.generator.utils.PluginUtils.createModuleDefinitionFromId;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
@@ -44,11 +46,19 @@ public class S3ModuleDescriptorLoader implements ModuleDescriptorLoader {
   public Optional<Map<String, Object>> findModuleDescriptor(ModuleRegistry registry, ModuleDefinition module) {
     var s3Registry = (S3ModuleRegistry) registry;
     var version = module.getVersion();
+    var id = module.getId();
     var filter = "latest".equals(version) ? module.getName() : module.getId();
     var fullPrefix = s3Registry.getPath() + filter;
 
-    return findLatestVersionByPrefix(s3Registry, fullPrefix)
-      .flatMap(foundS3Object -> readS3Object(foundS3Object, s3Registry));
+    Optional<S3Object> latestVersionByPrefix;
+    try {
+      latestVersionByPrefix = findLatestVersionByPrefix(module, s3Registry, fullPrefix);
+    } catch (Exception e) {
+      log.warn(format("Failed to find module descriptor '%s' in s3 bucket: %s", id, getBucketPath(s3Registry)), e);
+      return Optional.empty();
+    }
+
+    return latestVersionByPrefix.flatMap(foundS3Object -> readS3Object(id, foundS3Object, s3Registry));
   }
 
   @Override
@@ -56,61 +66,72 @@ public class S3ModuleDescriptorLoader implements ModuleDescriptorLoader {
     return RegistryType.AWS_S3;
   }
 
-  private Optional<S3Object> findLatestVersionByPrefix(S3ModuleRegistry s3Registry, String prefix) {
-    var request = buildListObjectsRequest(s3Registry, prefix, null);
+  private Optional<S3Object> findLatestVersionByPrefix(ModuleDefinition module, S3ModuleRegistry mr, String prefix) {
+    var request = buildListObjectsRequest(mr, prefix, null);
 
     ListObjectsV2Response result;
     Pair<Semver, S3Object> maxValueHolder = null;
 
     do {
       result = s3Client.listObjectsV2(request);
+
       var s3ObjectsByPrefix = result.contents();
       if (s3ObjectsByPrefix.isEmpty()) {
+        log.warn(format("Module '%s' is not found in s3 bucket: %s", module.getId(), getBucketPath(mr)));
         return Optional.empty();
       }
 
       for (var s3Object : s3ObjectsByPrefix) {
-        var nextMaxValue = tryFindNextMaxValue(s3Registry.getPath(), s3Object, maxValueHolder);
+        var nextMaxValue = tryFindNextMaxValue(mr.getPath(), module, s3Object, maxValueHolder);
         if (nextMaxValue != null) {
           maxValueHolder = nextMaxValue;
         }
       }
 
-      request = buildListObjectsRequest(s3Registry, prefix, result.nextContinuationToken());
+      request = buildListObjectsRequest(mr, prefix, result.nextContinuationToken());
     } while (TRUE.equals(result.isTruncated()));
 
     return ofNullable(maxValueHolder).map(Pair::getRight);
   }
 
-  private static Pair<Semver, S3Object> tryFindNextMaxValue(String prefix, S3Object o, Pair<Semver, S3Object> mv) {
-    var currentSemver = parseModuleVersion(o, prefix);
-    if (mv == null) {
-      return Pair.of(currentSemver, o);
-    }
-
-    if (currentSemver == null) {
+  private static Pair<Semver, S3Object> tryFindNextMaxValue(String prefix, ModuleDefinition module,
+    S3Object s3Object, Pair<Semver, S3Object> mv) {
+    var moduleNameAndVersionPair = parseS3ObjectKey(s3Object, prefix);
+    if (moduleNameAndVersionPair == null) {
       return null;
     }
 
+    if (!Objects.equals(moduleNameAndVersionPair.getLeft(), module.getName())) {
+      return null;
+    }
+
+    var semver = moduleNameAndVersionPair.getRight();
+    if (mv == null) {
+      return Pair.of(semver, s3Object);
+    }
+
     var maxSemver = mv.getLeft();
-    if (maxSemver == null || currentSemver.compareTo(maxSemver) > 0) {
-      return Pair.of(currentSemver, o);
+    if (semver.compareTo(maxSemver) > 0) {
+      return Pair.of(semver, s3Object);
     }
 
     return null;
   }
 
-  private Optional<Map<String, Object>> readS3Object(S3Object object, S3ModuleRegistry registry) {
+  private Optional<Map<String, Object>> readS3Object(String id, S3Object object, S3ModuleRegistry mr) {
     var request = GetObjectRequest.builder()
-      .bucket(registry.getBucket())
+      .bucket(mr.getBucket())
       .key(object.key())
       .build();
 
-    var responseBytes = s3Client.getObject(request, ResponseTransformer.toBytes());
     try {
-      return Optional.ofNullable(jsonConverter.parse(responseBytes.asInputStream(), new TypeReference<>() {}));
-    } catch (Exception exception) {
-      log.warn("Failed to get content from s3 object by key: " + object.key(), exception);
+      var responseBytes = s3Client.getObject(request, ResponseTransformer.toBytes());
+      var inputStream = responseBytes.asInputStream();
+      var moduleDescriptor = jsonConverter.parse(inputStream, new TypeReference<Map<String, Object>>() {});
+      log.info(format("Module descriptor '%s' loaded from s3 bucket: %s", id, getBucketPath(mr)));
+      return Optional.ofNullable(moduleDescriptor);
+    } catch (Exception e) {
+      log.warn(format("Failed to load module descriptor '%s' from s3 bucket: %s", id, getBucketPath(mr)), e);
       return Optional.empty();
     }
   }
@@ -124,7 +145,7 @@ public class S3ModuleDescriptorLoader implements ModuleDescriptorLoader {
       .build();
   }
 
-  private static Semver parseModuleVersion(S3Object s3Object, String pathPrefix) {
+  private static Pair<String, Semver> parseS3ObjectKey(S3Object s3Object, String pathPrefix) {
     var s3ObjectKey = s3Object.key();
     var fileName = s3ObjectKey.substring(pathPrefix.length());
 
@@ -135,8 +156,12 @@ public class S3ModuleDescriptorLoader implements ModuleDescriptorLoader {
       .orElse(fileName);
 
     return createModuleDefinitionFromId(moduleDescriptorId)
-      .map(ModuleDefinition::getVersion)
-      .map(Semver::parse)
+      .map(md -> Pair.of(md.getName(), Semver.parse(md.getVersion())))
+      .filter(pair -> pair.getRight() != null)
       .orElse(null);
+  }
+
+  private static String getBucketPath(S3ModuleRegistry s3ModuleRegistry) {
+    return s3ModuleRegistry.getBucket() + "/" + s3ModuleRegistry.getPath();
   }
 }

--- a/src/test/java/org/folio/app/generator/service/loader/S3ModuleDescriptorLoaderTest.java
+++ b/src/test/java/org/folio/app/generator/service/loader/S3ModuleDescriptorLoaderTest.java
@@ -124,44 +124,6 @@ class S3ModuleDescriptorLoaderTest {
   }
 
   @Test
-  void findModuleDescriptor_positive_singlePageWithSingleModuleDescriptor() {
-    var objectKey = "mod-foo-1.0.0.json";
-    var request = listObjectsRequest("mod-foo-1.0.0", null);
-    var listObjectsResponse = listObjectsResponse(s3Object(objectKey));
-    var expectedModuleDescriptor = fooModuleDescriptor("1.0.0");
-    var s3ObjectResponse = getObjectResponse(expectedModuleDescriptor);
-
-    when(s3Client.listObjectsV2(request)).thenReturn(listObjectsResponse);
-    when(s3Client.getObject(getObjectRequest(objectKey), toBytes())).thenReturn(s3ObjectResponse);
-    when(jsonConverter.parse(any(InputStream.class), any())).thenReturn(expectedModuleDescriptor);
-
-    var result = loader.findModuleDescriptor(s3Registry(), fooModule("1.0.0"));
-
-    assertThat(result).contains(expectedModuleDescriptor);
-    verify(log).info("Module descriptor 'mod-foo-1.0.0' loaded from s3 bucket: test-bucket/");
-    verify(pluginConfig, times(2)).getAwsS3BatchSize();
-  }
-
-  @Test
-  void findModuleDescriptor_positive_multiplePages() {
-    var objectKey = "mod-foo-1.0.0.json";
-    var request = listObjectsRequest("mod-foo-1.0.0", null);
-    var listObjectsResponse = listObjectsResponse(s3Object(objectKey));
-    var expectedModuleDescriptor = fooModuleDescriptor("1.0.0");
-    var s3ObjectResponse = getObjectResponse(expectedModuleDescriptor);
-
-    when(s3Client.listObjectsV2(request)).thenReturn(listObjectsResponse);
-    when(s3Client.getObject(getObjectRequest(objectKey), toBytes())).thenReturn(s3ObjectResponse);
-    when(jsonConverter.parse(any(InputStream.class), any())).thenReturn(expectedModuleDescriptor);
-
-    var result = loader.findModuleDescriptor(s3Registry(), fooModule("1.0.0"));
-
-    assertThat(result).contains(expectedModuleDescriptor);
-    verify(log).info("Module descriptor 'mod-foo-1.0.0' loaded from s3 bucket: test-bucket/");
-    verify(pluginConfig, times(2)).getAwsS3BatchSize();
-  }
-
-  @Test
   void findModuleDescriptor_positive_multiplePagesWithSingleModuleDescriptor() {
     var listObjectsResponse1 = listObjectsResponse("ct1",
       s3Object("mod-foo-1.0.0-SNAPSHOT.1"),

--- a/src/test/java/org/folio/app/generator/service/loader/S3ModuleDescriptorLoaderTest.java
+++ b/src/test/java/org/folio/app/generator/service/loader/S3ModuleDescriptorLoaderTest.java
@@ -1,0 +1,367 @@
+package org.folio.app.generator.service.loader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.core.ResponseBytes.fromByteArray;
+import static software.amazon.awssdk.core.sync.ResponseTransformer.toBytes;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.InputStream;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.apache.maven.plugin.logging.Log;
+import org.folio.app.generator.model.ModuleDefinition;
+import org.folio.app.generator.model.registry.S3ModuleRegistry;
+import org.folio.app.generator.model.types.RegistryType;
+import org.folio.app.generator.support.UnitTest;
+import org.folio.app.generator.utils.JsonConverter;
+import org.folio.app.generator.utils.PluginConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class S3ModuleDescriptorLoaderTest {
+
+  private static final String S3_BUCKET = "test-bucket";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @InjectMocks private S3ModuleDescriptorLoader loader;
+  @Mock private Log log;
+  @Mock private S3Client s3Client;
+  @Mock private JsonConverter jsonConverter;
+  @Spy private final PluginConfig pluginConfig = PluginConfig.builder().awsS3BatchSize(5).build();
+
+  @AfterEach
+  void tearDown() {
+    verifyNoMoreInteractions(log, jsonConverter, pluginConfig);
+  }
+
+  @Test
+  void getType_positive() {
+    assertThat(loader.getType()).isEqualTo(RegistryType.AWS_S3);
+  }
+
+  @Test
+  void findModuleDescriptor_positive_emptyResult() {
+    var request = listObjectsRequest("mod-foo-1.0.0", null);
+    var listObjectsResponse = listObjectsResponse();
+
+    when(s3Client.listObjectsV2(request)).thenReturn(listObjectsResponse);
+
+    var result = loader.findModuleDescriptor(s3Registry(), fooModule("1.0.0"));
+
+    assertThat(result).isEmpty();
+    verify(log).warn("Module 'mod-foo-1.0.0' is not found in s3 bucket: test-bucket/");
+    verify(pluginConfig).getAwsS3BatchSize();
+  }
+
+  @Test
+  void findModuleDescriptor_positive_singleModuleDescriptor() {
+    var objectKey = "mod-foo-1.0.0.json";
+    var request = listObjectsRequest("mod-foo-1.0.0", null);
+    var listObjectsResponse = listObjectsResponse(s3Object(objectKey));
+    var expectedModuleDescriptor = fooModuleDescriptor("1.0.0");
+    var s3ObjectResponse = getObjectResponse(expectedModuleDescriptor);
+
+    when(s3Client.listObjectsV2(request)).thenReturn(listObjectsResponse);
+    when(s3Client.getObject(getObjectRequest(objectKey), toBytes())).thenReturn(s3ObjectResponse);
+    when(jsonConverter.parse(any(InputStream.class), any())).thenReturn(expectedModuleDescriptor);
+
+    var result = loader.findModuleDescriptor(s3Registry(), fooModule("1.0.0"));
+
+    assertThat(result).contains(expectedModuleDescriptor);
+    verify(log).info("Module descriptor 'mod-foo-1.0.0' loaded from s3 bucket: test-bucket/");
+    verify(pluginConfig, times(2)).getAwsS3BatchSize();
+  }
+
+  @Test
+  void findModuleDescriptor_negative_listRequestFailed() {
+    var request = listObjectsRequest("mod-foo-1.0.0", null);
+    var exception = SdkClientException.create("error");
+
+    when(s3Client.listObjectsV2(request)).thenThrow(exception);
+
+    var result = loader.findModuleDescriptor(s3Registry(), fooModule("1.0.0"));
+
+    assertThat(result).isEmpty();
+    verify(log).warn("Failed to find module descriptor 'mod-foo-1.0.0' in s3 bucket: test-bucket/", exception);
+    verify(pluginConfig).getAwsS3BatchSize();
+  }
+
+  @Test
+  void findModuleDescriptor_negative_s3ObjectReadingFailed() {
+    var objectKey = "mod-foo-1.0.0.json";
+    var request = listObjectsRequest("mod-foo-1.0.0", null);
+    var listObjectsResponse = listObjectsResponse(s3Object(objectKey));
+
+    when(s3Client.listObjectsV2(request)).thenReturn(listObjectsResponse);
+    var exception = SdkClientException.create("error");
+    when(s3Client.getObject(getObjectRequest(objectKey), toBytes())).thenThrow(exception);
+
+    var result = loader.findModuleDescriptor(s3Registry(), fooModule("1.0.0"));
+
+    assertThat(result).isEmpty();
+    verify(log).warn("Failed to load module descriptor 'mod-foo-1.0.0' from s3 bucket: test-bucket/", exception);
+    verify(pluginConfig, times(2)).getAwsS3BatchSize();
+  }
+
+  @Test
+  void findModuleDescriptor_positive_singlePageWithSingleModuleDescriptor() {
+    var objectKey = "mod-foo-1.0.0.json";
+    var request = listObjectsRequest("mod-foo-1.0.0", null);
+    var listObjectsResponse = listObjectsResponse(s3Object(objectKey));
+    var expectedModuleDescriptor = fooModuleDescriptor("1.0.0");
+    var s3ObjectResponse = getObjectResponse(expectedModuleDescriptor);
+
+    when(s3Client.listObjectsV2(request)).thenReturn(listObjectsResponse);
+    when(s3Client.getObject(getObjectRequest(objectKey), toBytes())).thenReturn(s3ObjectResponse);
+    when(jsonConverter.parse(any(InputStream.class), any())).thenReturn(expectedModuleDescriptor);
+
+    var result = loader.findModuleDescriptor(s3Registry(), fooModule("1.0.0"));
+
+    assertThat(result).contains(expectedModuleDescriptor);
+    verify(log).info("Module descriptor 'mod-foo-1.0.0' loaded from s3 bucket: test-bucket/");
+    verify(pluginConfig, times(2)).getAwsS3BatchSize();
+  }
+
+  @Test
+  void findModuleDescriptor_positive_multiplePages() {
+    var objectKey = "mod-foo-1.0.0.json";
+    var request = listObjectsRequest("mod-foo-1.0.0", null);
+    var listObjectsResponse = listObjectsResponse(s3Object(objectKey));
+    var expectedModuleDescriptor = fooModuleDescriptor("1.0.0");
+    var s3ObjectResponse = getObjectResponse(expectedModuleDescriptor);
+
+    when(s3Client.listObjectsV2(request)).thenReturn(listObjectsResponse);
+    when(s3Client.getObject(getObjectRequest(objectKey), toBytes())).thenReturn(s3ObjectResponse);
+    when(jsonConverter.parse(any(InputStream.class), any())).thenReturn(expectedModuleDescriptor);
+
+    var result = loader.findModuleDescriptor(s3Registry(), fooModule("1.0.0"));
+
+    assertThat(result).contains(expectedModuleDescriptor);
+    verify(log).info("Module descriptor 'mod-foo-1.0.0' loaded from s3 bucket: test-bucket/");
+    verify(pluginConfig, times(2)).getAwsS3BatchSize();
+  }
+
+  @Test
+  void findModuleDescriptor_positive_multiplePagesWithSingleModuleDescriptor() {
+    var listObjectsResponse1 = listObjectsResponse("ct1",
+      s3Object("mod-foo-1.0.0-SNAPSHOT.1"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.2"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.3"));
+
+    var listObjectsResponse2 = listObjectsResponse("ct2",
+      s3Object("mod-foo-1.0.0-SNAPSHOT.4"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.5"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.6"));
+
+    var listObjectsResponse3 = listObjectsResponse(
+      s3Object("mod-foo-1.0.0-SNAPSHOT.7"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.8"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.9"));
+
+    var objectKey = "mod-foo-1.0.0-SNAPSHOT.9";
+    var expectedModuleDescriptor = fooModuleDescriptor("1.0.0-SNAPSHOT.9");
+    var s3ObjectResponse = getObjectResponse(expectedModuleDescriptor);
+
+    when(s3Client.listObjectsV2(listObjectsRequest("mod-foo", null))).thenReturn(listObjectsResponse1);
+    when(s3Client.listObjectsV2(listObjectsRequest("mod-foo", "ct1"))).thenReturn(listObjectsResponse2);
+    when(s3Client.listObjectsV2(listObjectsRequest("mod-foo", "ct2"))).thenReturn(listObjectsResponse3);
+    when(s3Client.getObject(getObjectRequest(objectKey), toBytes())).thenReturn(s3ObjectResponse);
+    when(jsonConverter.parse(any(InputStream.class), any())).thenReturn(expectedModuleDescriptor);
+
+    var result = loader.findModuleDescriptor(s3Registry(), fooModule("latest"));
+
+    assertThat(result).contains(expectedModuleDescriptor);
+
+    verify(log).info("Module descriptor 'mod-foo-latest' loaded from s3 bucket: test-bucket/");
+    verify(pluginConfig, times(4)).getAwsS3BatchSize();
+  }
+
+  @Test
+  void findModuleDescriptor_positive_latestVersionSearch() {
+    var request = listObjectsRequest("mod-foo", null);
+    var listObjectsResponse = listObjectsResponse(
+      s3Object("mod-foo-test"),
+      s3Object("mod-foo-1.0.0.15"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.4"),
+      s3Object("mod-foo-1.0.0"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.2"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.3"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.1.json"),
+      s3Object("mod-foo-1.1.0-SNAPSHOT.6"),
+      s3Object("mod-foo-1.1.0-SNAPSHOT.12"),
+      s3Object("mod-foo-1.1.0"),
+      s3Object("mod-foo-1.2.0-SNAPSHOT.198.json"),
+      s3Object("mod-foo-1.2.0"),
+      s3Object("mod-foo-1.2.0-SNAPSHOT.192"),
+      s3Object("mod-foo-1.3.0-SNAPSHOT.287.json"));
+    var expectedModuleDescriptor = fooModuleDescriptor("1.3.0-SNAPSHOT.287");
+    var s3ObjectResponse = getObjectResponse(expectedModuleDescriptor);
+    var objectKey = "mod-foo-1.3.0-SNAPSHOT.287.json";
+
+    when(s3Client.listObjectsV2(request)).thenReturn(listObjectsResponse);
+    when(s3Client.getObject(getObjectRequest(objectKey), toBytes())).thenReturn(s3ObjectResponse);
+    when(jsonConverter.parse(any(InputStream.class), any())).thenReturn(expectedModuleDescriptor);
+
+    var result = loader.findModuleDescriptor(s3Registry(), fooModule("latest"));
+
+    assertThat(result).contains(expectedModuleDescriptor);
+
+    verify(log).info("Module descriptor 'mod-foo-latest' loaded from s3 bucket: test-bucket/");
+    verify(pluginConfig, times(2)).getAwsS3BatchSize();
+  }
+
+  @Test
+  void findModuleDescriptor_positive_specificVersion() {
+    var request = listObjectsRequest("mod-foo-1.0.0", null);
+    var listObjectsResponse = listObjectsResponse(
+      s3Object("mod-foo-1.0.0-SNAPSHOT.4"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.2"),
+      s3Object("mod-foo-1.0.0.1"),
+      s3Object("mod-foo-1.0.0"),
+      s3Object("mod-foo-1.0.0.18"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.3"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.1"));
+    var expectedModuleDescriptor = fooModuleDescriptor("1.0.0");
+    var s3ObjectResponse = getObjectResponse(expectedModuleDescriptor);
+    var objectKey = "mod-foo-1.0.0";
+
+    when(s3Client.listObjectsV2(request)).thenReturn(listObjectsResponse);
+    when(s3Client.getObject(getObjectRequest(objectKey), toBytes())).thenReturn(s3ObjectResponse);
+    when(jsonConverter.parse(any(InputStream.class), any())).thenReturn(expectedModuleDescriptor);
+
+    var result = loader.findModuleDescriptor(s3Registry(), fooModule("1.0.0"));
+
+    assertThat(result).contains(expectedModuleDescriptor);
+
+    verify(log).info("Module descriptor 'mod-foo-1.0.0' loaded from s3 bucket: test-bucket/");
+    verify(pluginConfig, times(2)).getAwsS3BatchSize();
+  }
+
+  @Test
+  void findModuleDescriptor_positive_snapshotVersion() {
+    var request = listObjectsRequest("mod-foo-1.0.0-SNAPSHOT", null);
+    var listObjectsResponse = listObjectsResponse(
+      s3Object("mod-foo-1.0.0-SNAPSHOT.4"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.2"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.3"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.1"));
+    var expectedModuleDescriptor = fooModuleDescriptor("1.0.0-SNAPSHOT.4");
+    var s3ObjectResponse = getObjectResponse(expectedModuleDescriptor);
+    var objectKey = "mod-foo-1.0.0-SNAPSHOT.4";
+
+    when(s3Client.listObjectsV2(request)).thenReturn(listObjectsResponse);
+    when(s3Client.getObject(getObjectRequest(objectKey), toBytes())).thenReturn(s3ObjectResponse);
+    when(jsonConverter.parse(any(InputStream.class), any())).thenReturn(expectedModuleDescriptor);
+
+    var result = loader.findModuleDescriptor(s3Registry(), fooModule("1.0.0-SNAPSHOT"));
+
+    assertThat(result).contains(expectedModuleDescriptor);
+
+    verify(log).info("Module descriptor 'mod-foo-1.0.0-SNAPSHOT' loaded from s3 bucket: test-bucket/");
+    verify(pluginConfig, times(2)).getAwsS3BatchSize();
+  }
+
+  @Test
+  void findModuleDescriptor_positive_latestVersionForModuleWithSamePrefix() {
+    var request = listObjectsRequest("mod-foo", null);
+    var listObjectsResponse = listObjectsResponse(
+      s3Object("mod-foo-storage-1.2.0-SNAPSHOT.8"),
+      s3Object("mod-foo-storage-1.2.0-SNAPSHOT.9"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.1"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.2"),
+      s3Object("mod-foo-1.0.0-SNAPSHOT.3"));
+    var expectedModuleDescriptor = fooModuleDescriptor("1.0.0-SNAPSHOT.3");
+    var s3ObjectResponse = getObjectResponse(expectedModuleDescriptor);
+    var objectKey = "mod-foo-1.0.0-SNAPSHOT.3";
+
+    when(s3Client.listObjectsV2(request)).thenReturn(listObjectsResponse);
+    when(s3Client.getObject(getObjectRequest(objectKey), toBytes())).thenReturn(s3ObjectResponse);
+    when(jsonConverter.parse(any(InputStream.class), any())).thenReturn(expectedModuleDescriptor);
+
+    var result = loader.findModuleDescriptor(s3Registry(), fooModule("latest"));
+
+    assertThat(result).contains(expectedModuleDescriptor);
+
+    verify(log).info("Module descriptor 'mod-foo-latest' loaded from s3 bucket: test-bucket/");
+    verify(pluginConfig, times(2)).getAwsS3BatchSize();
+  }
+
+  private static Map<String, Object> fooModuleDescriptor(String version) {
+    return Map.of(
+      "id", "mod-foo" + "-" + version,
+      "name", "Test name for module: " + "mod-foo",
+      "description", "A description for module: " + "mod-foo"
+    );
+  }
+
+  private static ModuleDefinition fooModule(String version) {
+    return new ModuleDefinition().id("mod-foo-" + version).name("mod-foo").version(version);
+  }
+
+  private static GetObjectRequest getObjectRequest(String key) {
+    return GetObjectRequest.builder()
+      .key(key)
+      .bucket(S3_BUCKET)
+      .build();
+  }
+
+  @SneakyThrows
+  private static ResponseBytes<GetObjectResponse> getObjectResponse(Object content) {
+    var byteContent = OBJECT_MAPPER.writeValueAsBytes(content);
+    return fromByteArray(GetObjectResponse.builder().build(), byteContent);
+  }
+
+  private static ListObjectsV2Request listObjectsRequest(String prefix, String nct) {
+    return ListObjectsV2Request.builder()
+      .bucket(S3_BUCKET)
+      .prefix(prefix)
+      .maxKeys(5)
+      .continuationToken(nct)
+      .build();
+  }
+
+  private static ListObjectsV2Response listObjectsResponse(S3Object... s3Objects) {
+    return listObjectsResponse(null, s3Objects);
+  }
+
+  private static ListObjectsV2Response listObjectsResponse(String nct, S3Object... s3Objects) {
+    return ListObjectsV2Response.builder()
+      .contents(s3Objects)
+      .nextContinuationToken(nct)
+      .isTruncated(nct != null)
+      .build();
+  }
+
+  private static S3Object s3Object(String key) {
+    return S3Object.builder()
+      .key(key)
+      .build();
+  }
+
+  private static S3ModuleRegistry s3Registry() {
+    return new S3ModuleRegistry()
+      .path("")
+      .bucket(S3_BUCKET)
+      .withGeneratedFields();
+  }
+}


### PR DESCRIPTION
## Purpose

Fixes an issue for loading module descriptors by prefix:
module `mod-orders-latest` was replaced with `mod-orders-storage` with a greater version. 

## Approach

- Fix an issue for loading module descriptors from s3 bucket
- Add check for exact module name matching
- Add unit tests
