### PR TITLE
APPDESCRIP-12: Support for snapshot versions of UI modules

### DIFF
--- a/src/main/java/org/folio/app/generator/validator/ApplicationDependencyValidator.java
+++ b/src/main/java/org/folio/app/generator/validator/ApplicationDependencyValidator.java
@@ -35,7 +35,7 @@ public class ApplicationDependencyValidator {
    */
   public void validateDependencies(ApplicationDescriptorTemplate template) {
     var projectVersion = validateAndGetProjectVersion(template);
-    var errors = Stream.of(emptyIfNull(template.getModules()), emptyIfNull(template.getUiModules()))
+    var errors = Stream.of(emptyIfNull(template.getModules()))
       .map(moduleDependencies -> validateModules(projectVersion, moduleDependencies))
       .flatMap(Collection::stream)
       .collect(toList());


### PR DESCRIPTION
## Purpose
UI modules use a different naming convention for snapshot versions, e.g. folio_users-10.1.1000005167 the maven plugin for specializing application descriptor templates does not yet handle this appropriately.

[APPDESCRIP-12](https://folio-org.atlassian.net/browse/APPDESCRIP-12)
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach

- Disable UI modules Semver strict validation

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->
