### PR TITLE
EUREKA-414 Make module descriptor loading more durable

### DIFF
--- a/src/main/java/org/folio/app/generator/configuration/SpringConfiguration.java
+++ b/src/main/java/org/folio/app/generator/configuration/SpringConfiguration.java
@@ -36,9 +36,14 @@ public class SpringConfiguration {
   @Bean(name = "amazonS3Client")
   @Conditional(AwsCondition.class)
   public S3Client amazonS3Client(PluginConfig config) {
-    return S3Client.builder()
+    var builder = S3Client.builder()
       .region(config.getAwsRegion())
-      .credentialsProvider(DefaultCredentialsProvider.create())
-      .build();
+      .credentialsProvider(DefaultCredentialsProvider.create());
+
+    if (config.getAwsEndpointOverride() != null) {
+      builder.endpointOverride(config.getAwsEndpointOverride());
+    }
+
+    return builder.build();
   }
 }


### PR DESCRIPTION
## Purpose

Makes loading module descriptors more durable by providing retry on 504 response from okapi folio-registry

## Approach

- Adds retry ability for 504 status code from okapi folio-registry
- Adds missing functionality to be able to override AWS endpoint to be able to use local s3 (localstacks) deployment

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->
