### PR TITLE
EUREKA-715: fix missmatch version while searching exact MD

### DIFF
--- a/src/main/java/org/folio/app/generator/service/ApplicationDescriptorUpdateService.java
+++ b/src/main/java/org/folio/app/generator/service/ApplicationDescriptorUpdateService.java
@@ -122,13 +122,13 @@ public class ApplicationDescriptorUpdateService {
     var moduleNameVersion = modules.stream().collect(
       toMap(Dependency::getName, Dependency::getVersion, (v1, v2) -> v2));
 
-    var invalid = updateModuleNameVersion.entrySet()
-      .stream().filter(entry -> isInvalidModule(entry.getKey(), entry.getValue(), moduleNameVersion))
+    var invalid = updateModuleNameVersion.entrySet().stream()
+      .filter(entry -> isInvalidModule(entry.getKey(), entry.getValue(), moduleNameVersion))
       .map(entry -> new Dependency(entry.getKey(), entry.getValue())).toList();
 
     if (!invalid.isEmpty()) {
       throw new IllegalArgumentException("Invalid input modules to update:\n"
-        + collectToBulletedList(invalid.stream().map(Dependency::toString).toList()));
+        + collectToBulletedList(invalid.stream().map(ApplicationDescriptorUpdateService::mapToErrorMessage).toList()));
     }
   }
 
@@ -178,5 +178,9 @@ public class ApplicationDescriptorUpdateService {
       return Optional.of(new Dependency(name, LATEST_VERSION));
     }
     return splitModuleId(moduleId);
+  }
+
+  private static String mapToErrorMessage(Dependency dependency) {
+    return String.format("%s version older or the same: %s", dependency.getName(), dependency.getVersion());
   }
 }

--- a/src/test/java/org/folio/app/generator/service/ApplicationDescriptorUpdateServiceTest.java
+++ b/src/test/java/org/folio/app/generator/service/ApplicationDescriptorUpdateServiceTest.java
@@ -44,7 +44,9 @@ class ApplicationDescriptorUpdateServiceTest {
 
   @Test
   void update_negative_invalidModuleVersion() {
-    List<Map<String, Object>> modules = List.of(Map.of("id", "module1-1.0.0"), Map.of("id", "module2-2.0.0"),
+    List<Map<String, Object>> modules = List.of(
+      Map.of("id", "module1-1.0.0"),
+      Map.of("id", "module2-2.0.0"),
       Map.of("id", "module3:latest"));
     var application = new ApplicationDescriptor().moduleDescriptors(modules);
 


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/EUREKA-715
1) Module mod-example. We specified in template version 1.2.0. If there is no MD with released version 1.2.0, we expecting to have error - module descriptor not found. But, if there are snapshot versions with the same version, like 1.2.0.666-SNAPSHOT - this MD will be taken by generator.

2)  In case when we are trying to update versions of the modules that are already exist in app-descriptror - we are getting dependency issue. Example

## Approach

- fix error message while MD not found error
- add exact match if stable module version presented in a template (example: `mod-foo-1.3.0`)
- add/fix tests
