### PR TITLE
APPDESCRIP-74. Support per-registry custom HTTP headers for module registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,59 @@ Or via command-line: `-DmoduleUrlsOnly=true`
 
 ```
 
+#### Custom registry headers
+
+Okapi and Simple module registries can carry custom HTTP headers (for example, a security header
+required by a registry). Headers are attached per registry and are sent with every
+request the plugin makes to that specific registry (module-descriptor loading and version
+resolution). They are not sent to any other registry, which keeps secret values scoped to the
+registry they belong to.
+
+> Headers apply to `okapi` and `simple` (HTTP) registries. S3 registries use the AWS SDK and ignore
+> this setting.
+
+Via plugin configuration — add a `<headers>` block to a registry. Each header is a `<header>` with a
+`<name>` and `<value>`; **both** support Maven property and `${env.*}` interpolation, so the header
+name *and* value can be injected from secrets at build time:
+
+```xml
+<moduleRegistries>
+  <registry>
+    <type>okapi</type>
+    <url>https://folio-registry.dev.folio.org</url>
+    <headers>
+      <header>
+        <name>${env.HEADER_KEY}</name>
+        <value>${env.HEADER_VALUE}</value>
+      </header>
+    </headers>
+  </registry>
+</moduleRegistries>
+```
+
+> **Missing or empty secret:** if a header's name or value resolves to blank or is left as an
+> unresolved `${...}` placeholder (e.g. the secret is not set), that single header is **skipped with a
+> warning** and the request proceeds without it — the build does not fail and no malformed header is
+> sent.
+
+Via command-line — append an optional `::headers=` segment to the registry string. Multiple headers
+are separated by `;`, and each header is a `Name:Value` pair (only the first `:` separates the name
+from the value, so values may themselves contain `:`)
+
+```shell
+# single header
+-Dregistries="okapi::https://folio-registry.dev.folio.org::headers=X-Okapi-Token:${EUREKA_HEADER_VALUE}"
+
+# multiple headers
+-Dregistries="okapi::https://folio-registry.dev.folio.org::headers=X-Okapi-Token:secret;X-App:folio"
+
+# combined with a public url template
+-Dregistries="okapi::https://folio-registry.dev.folio.org::https://public.sample/{id}::headers=X-Okapi-Token:secret"
+```
+
+> Because `,` separates registries on the command line, it cannot be used inside a header segment —
+> use `;` to separate multiple headers for one registry.
+
 #### JSON Template example
 
 ```json
@@ -580,7 +633,7 @@ mvn install -DbuildNumber="123" -DawsRegion=us-east-1
 |--------------------------------|-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | awsRegion                      | us-east-1                                       | AWS Region for S3 client                                                                                                                                            |
 | buildNumber                    |                                                 | Build number from CI tool (will be added for any '-SNAPSHOT' version of generated application                                                                       |
-| registries                     |                                                 | Comma-separated list of custom module-descriptor registries in formats: `s3::{{bucket-name}}:{{path-to-folder}}`, `okapi::{{okapi-base}}`, `simple::{{okapi-base}}` |
+| registries                     |                                                 | Comma-separated list of custom module-descriptor registries in formats: `s3::{{bucket-name}}:{{path-to-folder}}`, `okapi::{{okapi-base}}`, `simple::{{okapi-base}}`. An optional `::headers=Key:Value;Key2:Value2` suffix adds custom HTTP headers sent with every request to that registry (see [Custom registry headers](#custom-registry-headers)) |
 | beRegistries                   |                                                 | Comma-separated list of custom back-end module-descriptor registries in the same format as `registries` parameter                                                   |
 | uiRegistries                   |                                                 | Comma-separated list of custom ui module-descriptor registries in the same format as `registries` parameter                                                         |
 | fallbackRegistries             |                                                 | Comma-separated list of fallback module-descriptor registries (same format as `registries`)                                                                         |

--- a/README.md
+++ b/README.md
@@ -141,6 +141,27 @@ from the value, so values may themselves contain `:`)
 > Because `,` separates registries on the command line, it cannot be used inside a header segment —
 > use `;` to separate multiple headers for one registry.
 
+##### Applying headers to pom-defined registries without changing them: `registryHeaders`
+
+When registries are defined in the pom and you only want to attach a header (e.g. a CI secret)
+without restating the registry list or editing each pom, use the `registryHeaders` parameter. It
+merges headers into the registries that are already configured (pom or command line):
+
+```shell
+# applies to ALL module registries
+-DregistryHeaders="X-Okapi-Token:secret"
+
+# only registries of a given type (okapi | simple | s3) via an optional "type::" prefix
+-DregistryHeaders="okapi::X-Okapi-Token:secret"
+
+# mix: X-App on all registries, X-Okapi-Token only on okapi ones (groups separated by ',')
+-DregistryHeaders="X-App:folio,okapi::X-Okapi-Token:secret"
+```
+
+Header syntax is the same `Name:Value;Name2:Value2` as above (split on the first `:`). A header
+already set on a registry (via its pom `<headers>` or `::headers=`) is **not** overridden by
+`registryHeaders` (per-registry config wins).
+
 #### JSON Template example
 
 ```json

--- a/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
+++ b/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
@@ -152,7 +152,7 @@ public abstract class AbstractGeneratorMojo extends AbstractMojo {
       .cmdUiPreReleaseArtifactRegistries(cmdUiPreReleaseArtifactRegistries)
       .build();
 
-    var registries = moduleRegistryProvider.getModuleRegistries(pluginConfig);
+    var registries = moduleRegistryProvider.getModuleRegistries(pluginConfig, getLog());
 
     return applicationContextBuilder
       .withLog(getLog())

--- a/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
+++ b/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
@@ -76,6 +76,9 @@ public abstract class AbstractGeneratorMojo extends AbstractMojo {
   @Parameter(name = "moduleUrlsOnly", property = "moduleUrlsOnly", defaultValue = "false")
   protected String moduleUrlsOnly;
 
+  @Parameter(defaultValue = "${registryHeaders}")
+  protected String registryHeaders;
+
   @Parameter(defaultValue = "${awsRegion}")
   protected String awsRegion;
 
@@ -138,6 +141,7 @@ public abstract class AbstractGeneratorMojo extends AbstractMojo {
       .uiCmdFallbackRegistryString(cmdUiFallbackRegistriesString)
       .overrideConfigRegistries(parseBoolean(overrideConfigRegistries))
       .moduleUrlsOnly(parseBoolean(moduleUrlsOnly))
+      .registryHeaders(registryHeaders)
       .awsRegion(isNotBlank(awsRegion) ? Region.of(awsRegion) : Region.US_EAST_1)
       .validateArtifacts(parseBoolean(validateArtifacts))
       .artifactRegistries(artifactRegistries)

--- a/src/main/java/org/folio/app/generator/model/registry/ConfigHeader.java
+++ b/src/main/java/org/folio/app/generator/model/registry/ConfigHeader.java
@@ -1,0 +1,19 @@
+package org.folio.app.generator.model.registry;
+
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+public class ConfigHeader {
+
+  /**
+   * HTTP header name.
+   */
+  private String name;
+
+  /**
+   * HTTP header value (may be a secret supplied via Maven property/environment interpolation).
+   */
+  @ToString.Exclude
+  private String value;
+}

--- a/src/main/java/org/folio/app/generator/model/registry/ConfigModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/ConfigModuleRegistry.java
@@ -1,5 +1,6 @@
 package org.folio.app.generator.model.registry;
 
+import java.util.List;
 import lombok.Data;
 import lombok.ToString;
 
@@ -31,4 +32,14 @@ public class ConfigModuleRegistry {
    * A name of the S3 bucket (used in S3 configuration).
    */
   private String bucket;
+
+  /**
+   * Custom HTTP headers sent with every request to this registry.
+   *
+   * <p>Each {@code <header>} has a {@code <name>} and {@code <value>}; both support Maven property
+   * and {@code ${env.*}} interpolation, so a secret header name and value can be injected at build
+   * time.</p>
+   */
+  @ToString.Exclude
+  private List<ConfigHeader> headers;
 }

--- a/src/main/java/org/folio/app/generator/model/registry/ModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/ModuleRegistry.java
@@ -1,5 +1,6 @@
 package org.folio.app.generator.model.registry;
 
+import java.util.Map;
 import org.folio.app.generator.model.types.RegistryType;
 
 public interface ModuleRegistry {
@@ -8,6 +9,13 @@ public interface ModuleRegistry {
    * Retrieves registry type.
    */
   RegistryType getType();
+
+  /**
+   * Retrieves custom HTTP headers to be sent with every request to this registry.
+   *
+   * @return map of header name to value, never {@code null} (empty when none configured)
+   */
+  Map<String, String> getHeaders();
 
   /**
    * Retrieves public URL template.

--- a/src/main/java/org/folio/app/generator/model/registry/OkapiModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/OkapiModuleRegistry.java
@@ -4,6 +4,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -17,6 +19,7 @@ public class OkapiModuleRegistry implements ModuleRegistry {
 
   private String url;
   private String publicUrl;
+  private Map<String, String> headers = new LinkedHashMap<>();
 
   /**
    * Sets url field and returns {@link OkapiModuleRegistry}.
@@ -25,6 +28,16 @@ public class OkapiModuleRegistry implements ModuleRegistry {
    */
   public OkapiModuleRegistry url(String url) {
     this.url = url;
+    return this;
+  }
+
+  /**
+   * Sets headers field and returns {@link OkapiModuleRegistry}.
+   *
+   * @return modified {@link OkapiModuleRegistry} value
+   */
+  public OkapiModuleRegistry headers(Map<String, String> headers) {
+    this.headers = headers;
     return this;
   }
 

--- a/src/main/java/org/folio/app/generator/model/registry/S3ModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/S3ModuleRegistry.java
@@ -2,6 +2,8 @@ package org.folio.app.generator.model.registry;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -17,6 +19,7 @@ public class S3ModuleRegistry implements ModuleRegistry {
   private String path;
   private String bucket;
   private String publicUrl;
+  private Map<String, String> headers = new LinkedHashMap<>();
 
   /**
    * Sets path field and returns {@link S3ModuleRegistry}.
@@ -45,6 +48,16 @@ public class S3ModuleRegistry implements ModuleRegistry {
    */
   public S3ModuleRegistry publicUrl(String publicUrl) {
     this.publicUrl = publicUrl;
+    return this;
+  }
+
+  /**
+   * Sets headers field and returns {@link S3ModuleRegistry}.
+   *
+   * @return modified {@link S3ModuleRegistry} value
+   */
+  public S3ModuleRegistry headers(Map<String, String> headers) {
+    this.headers = headers;
     return this;
   }
 

--- a/src/main/java/org/folio/app/generator/model/registry/SimpleModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/SimpleModuleRegistry.java
@@ -5,6 +5,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,6 +20,7 @@ public class SimpleModuleRegistry implements ModuleRegistry {
 
   private String url;
   private String publicUrl;
+  private Map<String, String> headers = new LinkedHashMap<>();
 
   /**
    * Sets url field and returns {@link SimpleModuleRegistry}.
@@ -26,6 +29,16 @@ public class SimpleModuleRegistry implements ModuleRegistry {
    */
   public SimpleModuleRegistry url(String url) {
     this.url = url;
+    return this;
+  }
+
+  /**
+   * Sets headers field and returns {@link SimpleModuleRegistry}.
+   *
+   * @return modified {@link SimpleModuleRegistry} value
+   */
+  public SimpleModuleRegistry headers(Map<String, String> headers) {
+    this.headers = headers;
     return this;
   }
 

--- a/src/main/java/org/folio/app/generator/service/ModuleRegistryProvider.java
+++ b/src/main/java/org/folio/app/generator/service/ModuleRegistryProvider.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import javax.inject.Inject;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ import org.folio.app.generator.model.registry.S3ModuleRegistry;
 import org.folio.app.generator.model.registry.SimpleModuleRegistry;
 import org.folio.app.generator.service.parsers.StringModuleRegistryParser;
 import org.folio.app.generator.utils.PluginConfig;
+import org.folio.app.generator.utils.RegistryHeaderParser;
 
 @RequiredArgsConstructor(onConstructor = @__(@Inject))
 public class ModuleRegistryProvider {
@@ -55,26 +57,42 @@ public class ModuleRegistryProvider {
       processor.getBeFallbackRegistries(),
       processor.getUiFallbackRegistries());
 
+    applyRegistryHeaders(registries, config.getRegistryHeaders());
     sanitizeHeaders(registries, log);
     return registries;
   }
 
+  private static void applyRegistryHeaders(ModuleRegistries registries, String registryHeaders) {
+    var scoped = RegistryHeaderParser.parseScoped(registryHeaders);
+    if (scoped.isEmpty()) {
+      return;
+    }
+
+    forEachUniqueRegistry(registries, registry ->
+      scoped.forType(registry.getType()).forEach(registry.getHeaders()::putIfAbsent));
+  }
+
   private static void sanitizeHeaders(ModuleRegistries registries, Log log) {
+    forEachUniqueRegistry(registries, registry ->
+      registry.getHeaders().entrySet().removeIf(entry -> {
+        if (isUnresolvedOrBlank(entry.getKey()) || isUnresolvedOrBlank(entry.getValue())) {
+          log.warn(String.format("Skipping header '%s' for registry '%s': name or value is empty or "
+            + "unresolved (a required secret/property may not be set)", entry.getKey(),
+            registry.getRegistryIdentifier()));
+          return true;
+        }
+        return false;
+      }));
+  }
+
+  private static void forEachUniqueRegistry(ModuleRegistries registries, Consumer<ModuleRegistry> action) {
     Set<ModuleRegistry> visited = Collections.newSetFromMap(new IdentityHashMap<>());
     var all = merge(registries.beRegistries(), registries.uiRegistries(),
       registries.beFallbackRegistries(), registries.uiFallbackRegistries());
 
     for (var registry : all) {
       if (visited.add(registry)) {
-        registry.getHeaders().entrySet().removeIf(entry -> {
-          if (isUnresolvedOrBlank(entry.getKey()) || isUnresolvedOrBlank(entry.getValue())) {
-            log.warn(String.format("Skipping header '%s' for registry '%s': name or value is empty or "
-              + "unresolved (a required secret/property may not be set)", entry.getKey(),
-              registry.getRegistryIdentifier()));
-            return true;
-          }
-          return false;
-        });
+        action.accept(registry);
       }
     }
   }

--- a/src/main/java/org/folio/app/generator/service/ModuleRegistryProvider.java
+++ b/src/main/java/org/folio/app/generator/service/ModuleRegistryProvider.java
@@ -13,11 +13,17 @@ import static org.folio.app.generator.utils.PluginUtils.collectToBulletedList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import javax.inject.Inject;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.logging.Log;
 import org.folio.app.generator.model.registry.ConfigModuleRegistry;
 import org.folio.app.generator.model.registry.ModuleRegistries;
 import org.folio.app.generator.model.registry.ModuleRegistry;
@@ -37,16 +43,44 @@ public class ModuleRegistryProvider {
    * Provides list of validated registries to load module descriptors.
    *
    * @param config -  initial plugin configuration as {@link PluginConfig} object
+   * @param log - Maven {@link Log} used to warn about skipped (unresolved/empty) headers
    * @return {@link List} with {@link ModuleRegistry} objects
    */
-  public ModuleRegistries getModuleRegistries(PluginConfig config) {
+  public ModuleRegistries getModuleRegistries(PluginConfig config, Log log) {
     var processor = new ModuleRegistryProcessor(config);
     handleInvalidRegistries(processor.getInvalidRegistries());
-    return new ModuleRegistries(
+    var registries = new ModuleRegistries(
       processor.getBeRegistries(),
       processor.getUiRegistries(),
       processor.getBeFallbackRegistries(),
       processor.getUiFallbackRegistries());
+
+    sanitizeHeaders(registries, log);
+    return registries;
+  }
+
+  private static void sanitizeHeaders(ModuleRegistries registries, Log log) {
+    Set<ModuleRegistry> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+    var all = merge(registries.beRegistries(), registries.uiRegistries(),
+      registries.beFallbackRegistries(), registries.uiFallbackRegistries());
+
+    for (var registry : all) {
+      if (visited.add(registry)) {
+        registry.getHeaders().entrySet().removeIf(entry -> {
+          if (isUnresolvedOrBlank(entry.getKey()) || isUnresolvedOrBlank(entry.getValue())) {
+            log.warn(String.format("Skipping header '%s' for registry '%s': name or value is empty or "
+              + "unresolved (a required secret/property may not be set)", entry.getKey(),
+              registry.getRegistryIdentifier()));
+            return true;
+          }
+          return false;
+        });
+      }
+    }
+  }
+
+  private static boolean isUnresolvedOrBlank(String value) {
+    return isBlank(value) || value.contains("${");
   }
 
   private ModuleRegistryProcessingResult processCommandLineRegistries(String registryString) {
@@ -101,24 +135,38 @@ public class ModuleRegistryProvider {
   }
 
   private static ModuleRegistry toModuleRegistry(ConfigModuleRegistry registry) {
+    var headers = headersOf(registry);
     if ("s3".equals(registry.getType())) {
       var path = defaultIfBlank(registry.getPath(), "");
       path = removeEnd(removeStart(path, PATH_DELIMITER), PATH_DELIMITER);
       return new S3ModuleRegistry()
         .path(StringUtils.isEmpty(path) ? path : path + PATH_DELIMITER)
         .bucket(trim(registry.getBucket()))
-        .publicUrl(trim(registry.getPublicUrlTemplate()));
+        .publicUrl(trim(registry.getPublicUrlTemplate()))
+        .headers(headers);
     }
 
     if ("simple".equals(registry.getType())) {
       return new SimpleModuleRegistry()
           .url(removeEnd(trim(registry.getUrl()), PATH_DELIMITER))
-          .publicUrl(trim(registry.getPublicUrlTemplate()));
+          .publicUrl(trim(registry.getPublicUrlTemplate()))
+          .headers(headers);
     }
 
     return new OkapiModuleRegistry()
       .url(removeEnd(trim(registry.getUrl()), PATH_DELIMITER))
-      .publicUrl(trim(registry.getPublicUrlTemplate()));
+      .publicUrl(trim(registry.getPublicUrlTemplate()))
+      .headers(headers);
+  }
+
+  private static Map<String, String> headersOf(ConfigModuleRegistry registry) {
+    var headers = new LinkedHashMap<String, String>();
+    if (registry.getHeaders() != null) {
+      for (var header : registry.getHeaders()) {
+        headers.put(header.getName(), header.getValue());
+      }
+    }
+    return headers;
   }
 
   @SafeVarargs

--- a/src/main/java/org/folio/app/generator/service/loader/HttpModuleDescriptorLoader.java
+++ b/src/main/java/org/folio/app/generator/service/loader/HttpModuleDescriptorLoader.java
@@ -7,7 +7,7 @@ import java.net.http.HttpResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.apache.maven.plugin.logging.Log;
-import org.folio.app.generator.utils.HttpRetryHelper;
+import org.folio.app.generator.utils.HttpRequestUtils;
 import org.folio.app.generator.utils.JsonConverter;
 import org.springframework.stereotype.Component;
 
@@ -21,10 +21,10 @@ public abstract class HttpModuleDescriptorLoader implements ModuleDescriptorLoad
 
   @SneakyThrows
   protected HttpResponse<InputStream> retryLoad(HttpRequest request) {
-    return HttpRetryHelper.sendWithRetry(httpClient, log, request);
+    return HttpRequestUtils.sendWithRetry(httpClient, log, request);
   }
 
   protected static String cleanUrl(String url) {
-    return HttpRetryHelper.cleanUrl(url);
+    return HttpRequestUtils.cleanUrl(url);
   }
 }

--- a/src/main/java/org/folio/app/generator/service/loader/OkapiModuleDescriptorLoader.java
+++ b/src/main/java/org/folio/app/generator/service/loader/OkapiModuleDescriptorLoader.java
@@ -17,6 +17,7 @@ import org.folio.app.generator.model.ModuleDefinition;
 import org.folio.app.generator.model.registry.ModuleRegistry;
 import org.folio.app.generator.model.registry.OkapiModuleRegistry;
 import org.folio.app.generator.model.types.RegistryType;
+import org.folio.app.generator.utils.HttpRequestUtils;
 import org.folio.app.generator.utils.JsonConverter;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -35,7 +36,7 @@ public class OkapiModuleDescriptorLoader extends HttpModuleDescriptorLoader {
     var okapiRegistry = (OkapiModuleRegistry) registry;
     var url = okapiRegistry.getUrl();
     try {
-      return loadModuleDescriptor(url, module).map(
+      return loadModuleDescriptor(url, module, okapiRegistry.getHeaders()).map(
         md -> new LoaderResultContainer()
           .sourceUrl(createDirectUrl(url, String.valueOf(md.get("id"))))
           .moduleDescriptor(md));
@@ -50,8 +51,9 @@ public class OkapiModuleDescriptorLoader extends HttpModuleDescriptorLoader {
     return RegistryType.OKAPI;
   }
 
-  private Optional<Map<String, Object>> loadModuleDescriptor(String url, ModuleDefinition module) {
-    var request = prepareHttpRequest(url, module);
+  private Optional<Map<String, Object>> loadModuleDescriptor(String url, ModuleDefinition module,
+    Map<String, String> headers) {
+    var request = prepareHttpRequest(url, module, headers);
     var moduleId = module.getId();
 
     var response = retryLoad(request);
@@ -79,14 +81,17 @@ public class OkapiModuleDescriptorLoader extends HttpModuleDescriptorLoader {
     return new URL(cleanBaseUrl + "/_/proxy/modules/" + moduleId);
   }
 
-  private static HttpRequest prepareHttpRequest(String url, ModuleDefinition module) {
+  private static HttpRequest prepareHttpRequest(String url, ModuleDefinition module, Map<String, String> headers) {
     var baseUrl = cleanUrl(url);
-    return HttpRequest.newBuilder()
+    var builder = HttpRequest.newBuilder()
       .GET()
       .uri(URI.create(prepareUriString(baseUrl, module)))
       .timeout(Duration.ofMinutes(5))
-      .version(Version.HTTP_1_1)
-      .build();
+      .version(Version.HTTP_1_1);
+
+    HttpRequestUtils.applyHeaders(builder, headers);
+
+    return builder.build();
   }
 
   private static String prepareUriString(String baseUrl, ModuleDefinition module) {

--- a/src/main/java/org/folio/app/generator/service/loader/SimpleModuleDescriptorLoader.java
+++ b/src/main/java/org/folio/app/generator/service/loader/SimpleModuleDescriptorLoader.java
@@ -16,6 +16,7 @@ import org.folio.app.generator.model.ModuleDefinition;
 import org.folio.app.generator.model.registry.ModuleRegistry;
 import org.folio.app.generator.model.registry.SimpleModuleRegistry;
 import org.folio.app.generator.model.types.RegistryType;
+import org.folio.app.generator.utils.HttpRequestUtils;
 import org.folio.app.generator.utils.JsonConverter;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -32,7 +33,7 @@ public class SimpleModuleDescriptorLoader extends HttpModuleDescriptorLoader {
   public Optional<LoaderResultContainer> findModuleDescriptor(ModuleRegistry registry,
     ModuleDefinition module) {
     var simpleRegistry = (SimpleModuleRegistry) registry;
-    var request = prepareHttpRequest(simpleRegistry.getUrl(), module);
+    var request = prepareHttpRequest(simpleRegistry.getUrl(), module, simpleRegistry.getHeaders());
 
     try {
       return loadModuleDescriptor(request, module).map(
@@ -81,13 +82,16 @@ public class SimpleModuleDescriptorLoader extends HttpModuleDescriptorLoader {
     return new URL(cleanBaseUrl + "/" + moduleId);
   }
 
-  private static HttpRequest prepareHttpRequest(String url, ModuleDefinition module) {
-    return HttpRequest.newBuilder()
+  private static HttpRequest prepareHttpRequest(String url, ModuleDefinition module, Map<String, String> headers) {
+    var builder = HttpRequest.newBuilder()
       .GET()
       .uri(URI.create(prepareUriString(url, module)))
       .timeout(Duration.ofMinutes(5))
-      .version(Version.HTTP_1_1)
-      .build();
+      .version(Version.HTTP_1_1);
+
+    HttpRequestUtils.applyHeaders(builder, headers);
+
+    return builder.build();
   }
 
   private static String prepareUriString(String url, ModuleDefinition module) {

--- a/src/main/java/org/folio/app/generator/service/parsers/StringModuleRegistryParser.java
+++ b/src/main/java/org/folio/app/generator/service/parsers/StringModuleRegistryParser.java
@@ -7,9 +7,11 @@ import static org.folio.app.generator.utils.PluginUtils.PATH_DELIMITER;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
@@ -21,6 +23,10 @@ import org.folio.app.generator.model.registry.SimpleModuleRegistry;
 
 public class StringModuleRegistryParser {
 
+  private static final String HEADERS_MARKER = "::headers=";
+  private static final String HEADER_PAIR_DELIMITER = ";";
+  private static final String HEADER_KEY_VALUE_DELIMITER = ":";
+
   private final Pattern okapiPattern1 = Pattern.compile("(okapi)::(.{1,1024})::(.{1,1024})");
   private final Pattern okapiPattern2 = Pattern.compile("(okapi)::(.{1,1024})");
   private final Pattern s3Pattern1 = Pattern.compile("(s3)::(.{1,1024})::(.{1,1024})::(.{1,1024})");
@@ -28,7 +34,7 @@ public class StringModuleRegistryParser {
   private final Pattern simplePattern1 = Pattern.compile("(simple)::(.{1,1024})::(.{1,1024})");
   private final Pattern simplePattern2 = Pattern.compile("(simple)::(.{1,1024})");
 
-  private final List<Pair<Pattern, Function<String[], ModuleRegistry>>> patterns = List.of(
+  private final List<Pair<Pattern, BiFunction<String[], Map<String, String>, ModuleRegistry>>> patterns = List.of(
     Pair.of(okapiPattern1, StringModuleRegistryParser::parseOkapiString),
     Pair.of(okapiPattern2, StringModuleRegistryParser::parseOkapiString),
     Pair.of(s3Pattern1, StringModuleRegistryParser::parseAwsS3String),
@@ -48,16 +54,44 @@ public class StringModuleRegistryParser {
     }
 
     var value = registryString.trim();
+
+    var headers = new LinkedHashMap<String, String>();
+    var headersMarkerIndex = value.indexOf(HEADERS_MARKER);
+    if (headersMarkerIndex >= 0) {
+      headers.putAll(parseHeaders(value.substring(headersMarkerIndex + HEADERS_MARKER.length())));
+      value = value.substring(0, headersMarkerIndex);
+    }
+
     for (var patternPair : patterns) {
       var pattern = patternPair.getLeft();
       var matcher = pattern.matcher(value);
       if (matcher.matches()) {
         var stringParts = convertToStringPartsArray(matcher);
-        return Optional.of(patternPair.getRight().apply(stringParts));
+        return Optional.of(patternPair.getRight().apply(stringParts, headers));
       }
     }
 
     return Optional.empty();
+  }
+
+  private static Map<String, String> parseHeaders(String headersString) {
+    var headers = new LinkedHashMap<String, String>();
+    if (StringUtils.isBlank(headersString)) {
+      return headers;
+    }
+
+    for (var pair : headersString.split(HEADER_PAIR_DELIMITER)) {
+      var delimiterIndex = pair.indexOf(HEADER_KEY_VALUE_DELIMITER);
+      if (delimiterIndex > 0) {
+        var key = trim(pair.substring(0, delimiterIndex));
+        var headerValue = trim(pair.substring(delimiterIndex + 1));
+        if (StringUtils.isNotEmpty(key)) {
+          headers.put(key, headerValue);
+        }
+      }
+    }
+
+    return headers;
   }
 
   private static String[] convertToStringPartsArray(Matcher matcher) {
@@ -69,26 +103,28 @@ public class StringModuleRegistryParser {
     return pathParts;
   }
 
-  private static ModuleRegistry parseOkapiString(String[] stringParts) {
+  private static ModuleRegistry parseOkapiString(String[] stringParts, Map<String, String> headers) {
     var baseUrl = checkAndGetUrl(stringParts[1]);
     var verifiedUrl = baseUrl.toString();
 
-    var s3ModuleRegistry = new OkapiModuleRegistry();
-    s3ModuleRegistry.setUrl(verifiedUrl);
+    var registry = new OkapiModuleRegistry();
+    registry.setUrl(verifiedUrl);
+    registry.setHeaders(headers);
 
     if (stringParts.length == 3) {
-      s3ModuleRegistry.setPublicUrl(trim(stringParts[2]));
+      registry.setPublicUrl(trim(stringParts[2]));
     }
 
-    return s3ModuleRegistry.withGeneratedFields();
+    return registry.withGeneratedFields();
   }
 
-  private static ModuleRegistry parseSimpleString(String[] stringParts) {
+  private static ModuleRegistry parseSimpleString(String[] stringParts, Map<String, String> headers) {
     var baseUrl = checkAndGetUrl(stringParts[1]);
     var verifiedUrl = baseUrl.toString();
 
     var registry = new SimpleModuleRegistry();
     registry.setUrl(verifiedUrl);
+    registry.setHeaders(headers);
 
     if (stringParts.length == 3) {
       registry.setPublicUrl(trim(stringParts[2]));
@@ -105,13 +141,14 @@ public class StringModuleRegistryParser {
     }
   }
 
-  private static S3ModuleRegistry parseAwsS3String(String[] stringParts) {
+  private static S3ModuleRegistry parseAwsS3String(String[] stringParts, Map<String, String> headers) {
     var s3ModuleRegistry = new S3ModuleRegistry();
     var bucket = stringParts[1];
     var path = removeEnd(removeStart(trim(stringParts[2]), PATH_DELIMITER), PATH_DELIMITER);
 
     s3ModuleRegistry.setBucket(trim(bucket));
     s3ModuleRegistry.setPath(path.isEmpty() ? path : path + PATH_DELIMITER);
+    s3ModuleRegistry.setHeaders(headers);
 
     if (stringParts.length == 4) {
       s3ModuleRegistry.setPublicUrl(trim(stringParts[3]));

--- a/src/main/java/org/folio/app/generator/service/parsers/StringModuleRegistryParser.java
+++ b/src/main/java/org/folio/app/generator/service/parsers/StringModuleRegistryParser.java
@@ -20,12 +20,11 @@ import org.folio.app.generator.model.registry.ModuleRegistry;
 import org.folio.app.generator.model.registry.OkapiModuleRegistry;
 import org.folio.app.generator.model.registry.S3ModuleRegistry;
 import org.folio.app.generator.model.registry.SimpleModuleRegistry;
+import org.folio.app.generator.utils.RegistryHeaderParser;
 
 public class StringModuleRegistryParser {
 
   private static final String HEADERS_MARKER = "::headers=";
-  private static final String HEADER_PAIR_DELIMITER = ";";
-  private static final String HEADER_KEY_VALUE_DELIMITER = ":";
 
   private final Pattern okapiPattern1 = Pattern.compile("(okapi)::(.{1,1024})::(.{1,1024})");
   private final Pattern okapiPattern2 = Pattern.compile("(okapi)::(.{1,1024})");
@@ -58,7 +57,7 @@ public class StringModuleRegistryParser {
     var headers = new LinkedHashMap<String, String>();
     var headersMarkerIndex = value.indexOf(HEADERS_MARKER);
     if (headersMarkerIndex >= 0) {
-      headers.putAll(parseHeaders(value.substring(headersMarkerIndex + HEADERS_MARKER.length())));
+      headers.putAll(RegistryHeaderParser.parseHeaders(value.substring(headersMarkerIndex + HEADERS_MARKER.length())));
       value = value.substring(0, headersMarkerIndex);
     }
 
@@ -72,26 +71,6 @@ public class StringModuleRegistryParser {
     }
 
     return Optional.empty();
-  }
-
-  private static Map<String, String> parseHeaders(String headersString) {
-    var headers = new LinkedHashMap<String, String>();
-    if (StringUtils.isBlank(headersString)) {
-      return headers;
-    }
-
-    for (var pair : headersString.split(HEADER_PAIR_DELIMITER)) {
-      var delimiterIndex = pair.indexOf(HEADER_KEY_VALUE_DELIMITER);
-      if (delimiterIndex > 0) {
-        var key = trim(pair.substring(0, delimiterIndex));
-        var headerValue = trim(pair.substring(delimiterIndex + 1));
-        if (StringUtils.isNotEmpty(key)) {
-          headers.put(key, headerValue);
-        }
-      }
-    }
-
-    return headers;
   }
 
   private static String[] convertToStringPartsArray(Matcher matcher) {

--- a/src/main/java/org/folio/app/generator/service/resolver/OkapiModuleVersionResolver.java
+++ b/src/main/java/org/folio/app/generator/service/resolver/OkapiModuleVersionResolver.java
@@ -22,7 +22,7 @@ import org.folio.app.generator.model.types.ErrorCategory;
 import org.folio.app.generator.model.types.ModuleType;
 import org.folio.app.generator.model.types.RegistryType;
 import org.folio.app.generator.service.exceptions.ApplicationGeneratorException;
-import org.folio.app.generator.utils.HttpRetryHelper;
+import org.folio.app.generator.utils.HttpRequestUtils;
 import org.folio.app.generator.utils.JsonConverter;
 import org.folio.app.generator.utils.PluginUtils;
 import org.springframework.context.annotation.Conditional;
@@ -42,7 +42,7 @@ public class OkapiModuleVersionResolver implements ModuleVersionResolver {
     var okapiRegistry = (OkapiModuleRegistry) registry;
     var url = okapiRegistry.getUrl();
     try {
-      return getVersions(url, module, type);
+      return getVersions(url, module, type, okapiRegistry.getHeaders());
     } catch (IOException e) {
       log.warn(String.format("Failed to fetch versions for module '%s' from %s", module.getName(), url), e);
       var errorMsg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
@@ -62,11 +62,12 @@ public class OkapiModuleVersionResolver implements ModuleVersionResolver {
     return RegistryType.OKAPI;
   }
 
-  private Optional<List<String>> getVersions(String url, Dependency module, ModuleType type) throws Exception {
-    var request = prepareHttpRequest(url, module, type);
+  private Optional<List<String>> getVersions(String url, Dependency module, ModuleType type,
+    Map<String, String> headers) throws Exception {
+    var request = prepareHttpRequest(url, module, type, headers);
     var moduleName = module.getName();
 
-    var response = HttpRetryHelper.sendWithRetry(httpClient, log, request);
+    var response = HttpRequestUtils.sendWithRetry(httpClient, log, request);
     var responseStatus = response.statusCode();
 
     if (responseStatus != 200) {
@@ -96,14 +97,18 @@ public class OkapiModuleVersionResolver implements ModuleVersionResolver {
     return Optional.of(versions);
   }
 
-  private static HttpRequest prepareHttpRequest(String url, Dependency module, ModuleType type) {
-    var baseUrl = HttpRetryHelper.cleanUrl(url);
-    return HttpRequest.newBuilder()
+  private static HttpRequest prepareHttpRequest(String url, Dependency module, ModuleType type,
+    Map<String, String> headers) {
+    var baseUrl = HttpRequestUtils.cleanUrl(url);
+    var builder = HttpRequest.newBuilder()
       .GET()
       .uri(URI.create(prepareUriString(baseUrl, module, type)))
       .timeout(Duration.ofMinutes(5))
-      .version(Version.HTTP_1_1)
-      .build();
+      .version(Version.HTTP_1_1);
+
+    HttpRequestUtils.applyHeaders(builder, headers);
+
+    return builder.build();
   }
 
   private static String prepareUriString(String baseUrl, Dependency module, ModuleType type) {

--- a/src/main/java/org/folio/app/generator/service/resolver/SimpleModuleVersionResolver.java
+++ b/src/main/java/org/folio/app/generator/service/resolver/SimpleModuleVersionResolver.java
@@ -20,6 +20,7 @@ import org.folio.app.generator.model.registry.ModuleRegistry;
 import org.folio.app.generator.model.registry.SimpleModuleRegistry;
 import org.folio.app.generator.model.types.ModuleType;
 import org.folio.app.generator.model.types.RegistryType;
+import org.folio.app.generator.utils.HttpRequestUtils;
 import org.folio.app.generator.utils.JsonConverter;
 import org.folio.app.generator.utils.PluginUtils;
 import org.folio.app.generator.utils.SemverUtils;
@@ -42,13 +43,15 @@ public class SimpleModuleVersionResolver implements ModuleVersionResolver {
     var preRelease = dependency.getPreRelease();
 
     try {
-      var request = HttpRequest.newBuilder()
+      var requestBuilder = HttpRequest.newBuilder()
         .GET()
         .uri(URI.create(cleanUrl(simpleRegistry.getUrl())))
         .timeout(Duration.ofMinutes(5))
-        .version(Version.HTTP_1_1)
-        .build();
+        .version(Version.HTTP_1_1);
 
+      HttpRequestUtils.applyHeaders(requestBuilder, simpleRegistry.getHeaders());
+
+      var request = requestBuilder.build();
       var response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
 
       if (response.statusCode() != 200) {

--- a/src/main/java/org/folio/app/generator/utils/HttpRequestUtils.java
+++ b/src/main/java/org/folio/app/generator/utils/HttpRequestUtils.java
@@ -8,12 +8,13 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
+import java.util.Map;
 import java.util.Set;
 import lombok.experimental.UtilityClass;
 import org.apache.maven.plugin.logging.Log;
 
 @UtilityClass
-public class HttpRetryHelper {
+public class HttpRequestUtils {
 
   public static final Set<Integer> RETRYABLE_STATUS_CODES = Set.of(429, 500, 502, 503, 504);
   public static final int RETRYABLE_ATTEMPTS_NUMBER = 5;
@@ -50,5 +51,19 @@ public class HttpRetryHelper {
 
   public static String cleanUrl(String url) {
     return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+  }
+
+  /**
+   * Adds the provided custom headers to the given request builder.
+   *
+   * @param builder - {@link HttpRequest.Builder} to enrich with headers
+   * @param headers - map of header name to value, may be {@code null} or empty
+   */
+  public static void applyHeaders(HttpRequest.Builder builder, Map<String, String> headers) {
+    if (headers == null || headers.isEmpty()) {
+      return;
+    }
+
+    headers.forEach(builder::header);
   }
 }

--- a/src/main/java/org/folio/app/generator/utils/PluginConfig.java
+++ b/src/main/java/org/folio/app/generator/utils/PluginConfig.java
@@ -33,6 +33,8 @@ public class PluginConfig {
   private final boolean moduleUrlsOnly;
   private final boolean overrideConfigRegistries;
 
+  private final String registryHeaders;
+
   private final Region awsRegion;
   private final URI awsEndpointOverride;
 

--- a/src/main/java/org/folio/app/generator/utils/RegistryHeaderParser.java
+++ b/src/main/java/org/folio/app/generator/utils/RegistryHeaderParser.java
@@ -1,0 +1,126 @@
+package org.folio.app.generator.utils;
+
+import static org.apache.commons.lang3.StringUtils.trim;
+
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.app.generator.model.types.RegistryType;
+
+/**
+ * Parses custom registry HTTP header strings.
+ *
+ * <p>A header list has the form {@code Name:Value;Name2:Value2} (split on the first {@code :}, so
+ * values may contain {@code :}). The scoped form additionally supports an optional {@code type::}
+ * prefix and comma-separated groups: {@code X-App:folio,okapi::X-Okapi-Token:secret}.</p>
+ */
+public final class RegistryHeaderParser {
+
+  private static final String GROUP_DELIMITER = ",";
+  private static final String SCOPE_DELIMITER = "::";
+  private static final String HEADER_PAIR_DELIMITER = ";";
+  private static final String HEADER_KEY_VALUE_DELIMITER = ":";
+
+  private RegistryHeaderParser() {}
+
+  /**
+   * Parses a {@code Name:Value;Name2:Value2} header list into an ordered map.
+   *
+   * @param headersString - header list string, may be {@code null}/blank
+   * @return ordered map of header name to value (empty when nothing parseable)
+   */
+  public static Map<String, String> parseHeaders(String headersString) {
+    var headers = new LinkedHashMap<String, String>();
+    if (StringUtils.isBlank(headersString)) {
+      return headers;
+    }
+
+    for (var pair : headersString.split(HEADER_PAIR_DELIMITER)) {
+      var delimiterIndex = pair.indexOf(HEADER_KEY_VALUE_DELIMITER);
+      if (delimiterIndex > 0) {
+        var key = trim(pair.substring(0, delimiterIndex));
+        var headerValue = trim(pair.substring(delimiterIndex + 1));
+        if (StringUtils.isNotEmpty(key)) {
+          headers.put(key, headerValue);
+        }
+      }
+    }
+
+    return headers;
+  }
+
+  /**
+   * Parses the {@code registryHeaders} parameter grammar (optional {@code type::} prefix per
+   * comma-separated group) into global and per-type header maps.
+   *
+   * @param value - the {@code registryHeaders} value, may be {@code null}/blank
+   * @return {@link ScopedHeaders} holding the global map and per-type maps
+   */
+  public static ScopedHeaders parseScoped(String value) {
+    var global = new LinkedHashMap<String, String>();
+    var byType = new EnumMap<RegistryType, Map<String, String>>(RegistryType.class);
+    if (StringUtils.isBlank(value)) {
+      return new ScopedHeaders(global, byType);
+    }
+
+    for (var group : value.split(GROUP_DELIMITER)) {
+      var trimmedGroup = trim(group);
+      if (StringUtils.isEmpty(trimmedGroup)) {
+        continue;
+      }
+
+      var type = scopeOf(trimmedGroup);
+      var headerList = type == null
+        ? trimmedGroup
+        : trimmedGroup.substring(trimmedGroup.indexOf(SCOPE_DELIMITER) + SCOPE_DELIMITER.length());
+
+      var parsed = parseHeaders(headerList);
+      if (type == null) {
+        global.putAll(parsed);
+      } else {
+        byType.computeIfAbsent(type, key -> new LinkedHashMap<>()).putAll(parsed);
+      }
+    }
+
+    return new ScopedHeaders(global, byType);
+  }
+
+  private static RegistryType scopeOf(String group) {
+    var scopeIndex = group.indexOf(SCOPE_DELIMITER);
+    if (scopeIndex <= 0) {
+      return null;
+    }
+
+    var prefix = trim(group.substring(0, scopeIndex));
+    for (var registryType : RegistryType.values()) {
+      if (registryType.getValue().equalsIgnoreCase(prefix)) {
+        return registryType;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Holds parsed {@code registryHeaders}: a global header map plus per-type overrides.
+   */
+  public record ScopedHeaders(Map<String, String> global, Map<RegistryType, Map<String, String>> byType) {
+
+    /**
+     * Returns the headers applicable to a registry of the given type: the global headers, with any
+     * type-specific entries layered on top (type-specific wins on a name collision).
+     */
+    public Map<String, String> forType(RegistryType type) {
+      var result = new LinkedHashMap<>(global);
+      var typed = byType.get(type);
+      if (typed != null) {
+        result.putAll(typed);
+      }
+      return result;
+    }
+
+    public boolean isEmpty() {
+      return global.isEmpty() && byType.values().stream().allMatch(Map::isEmpty);
+    }
+  }
+}

--- a/src/test/java/org/folio/app/generator/service/ModuleRegistryProviderTest.java
+++ b/src/test/java/org/folio/app/generator/service/ModuleRegistryProviderTest.java
@@ -117,6 +117,63 @@ class ModuleRegistryProviderTest {
   }
 
   @Test
+  void getModuleRegistries_positive_registryHeadersParamMergedIntoRegistries() {
+    var config = PluginConfig.builder()
+      .registries(List.of(okapiConfigRegistry()))
+      .registryHeaders("X-Okapi-Token:secret")
+      .build();
+
+    var result = moduleRegistryProvider.getModuleRegistries(config, log);
+
+    assertThat(result.beRegistries()).singleElement()
+      .satisfies(registry -> assertThat(registry.getHeaders())
+        .containsExactlyEntriesOf(Map.of("X-Okapi-Token", "secret")));
+  }
+
+  @Test
+  void getModuleRegistries_positive_registryHeadersParamTypeScopedSkipsOtherTypes() {
+    var config = PluginConfig.builder()
+      .registries(List.of(okapiConfigRegistry()))
+      .registryHeaders("simple::X-Sim:v")
+      .build();
+
+    var result = moduleRegistryProvider.getModuleRegistries(config, log);
+
+    assertThat(result.beRegistries()).singleElement()
+      .satisfies(registry -> assertThat(registry.getHeaders()).isEmpty());
+  }
+
+  @Test
+  void getModuleRegistries_positive_perRegistryHeaderWinsOverParam() {
+    var configRegistry = okapiConfigRegistry();
+    configRegistry.setHeaders(List.of(configHeader("X-Token", "pom")));
+    var config = PluginConfig.builder()
+      .registries(List.of(configRegistry))
+      .registryHeaders("X-Token:param;X-Extra:e")
+      .build();
+
+    var result = moduleRegistryProvider.getModuleRegistries(config, log);
+
+    assertThat(result.beRegistries()).singleElement()
+      .satisfies(registry -> assertThat(registry.getHeaders())
+        .containsExactlyInAnyOrderEntriesOf(orderedHeaders("X-Token", "pom", "X-Extra", "e")));
+  }
+
+  @Test
+  void getModuleRegistries_positive_registryHeadersParamUnresolvedDropped() {
+    var config = PluginConfig.builder()
+      .registries(List.of(okapiConfigRegistry()))
+      .registryHeaders("X-Token:${env.MISSING}")
+      .build();
+
+    var result = moduleRegistryProvider.getModuleRegistries(config, log);
+
+    assertThat(result.beRegistries()).singleElement()
+      .satisfies(registry -> assertThat(registry.getHeaders()).isEmpty());
+    verify(log).warn(contains("Skipping header 'X-Token'"));
+  }
+
+  @Test
   void getModuleRegistries_negative_unsupportedType() {
     var config = PluginConfig.builder().registries(List.of(unknownModuleRegistry())).build();
 

--- a/src/test/java/org/folio/app/generator/service/ModuleRegistryProviderTest.java
+++ b/src/test/java/org/folio/app/generator/service/ModuleRegistryProviderTest.java
@@ -4,9 +4,18 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
+import org.apache.maven.plugin.logging.Log;
+import org.folio.app.generator.model.registry.ConfigHeader;
 import org.folio.app.generator.model.registry.ConfigModuleRegistry;
 import org.folio.app.generator.model.registry.ModuleRegistries;
 import org.folio.app.generator.model.registry.ModuleRegistry;
@@ -26,6 +35,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ModuleRegistryProviderTest {
 
   private ModuleRegistryProvider moduleRegistryProvider;
+  private final Log log = mock(Log.class);
 
   @BeforeEach
   void setUp() {
@@ -36,15 +46,81 @@ class ModuleRegistryProviderTest {
   @ParameterizedTest(name = "[{index}] {0}")
   void getModuleRegistries_positive_parameterized(@SuppressWarnings("unused") String name,
     PluginConfig config, ModuleRegistries expected) {
-    var result = moduleRegistryProvider.getModuleRegistries(config);
+    var result = moduleRegistryProvider.getModuleRegistries(config, log);
     assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void getModuleRegistries_positive_configHeadersFlowToRegistry() {
+    var configRegistry = okapiConfigRegistry();
+    configRegistry.setHeaders(List.of(configHeader("X-Okapi-Token", "secret"), configHeader("X-App", "folio")));
+    var config = PluginConfig.builder().registries(List.of(configRegistry)).build();
+
+    var result = moduleRegistryProvider.getModuleRegistries(config, log);
+
+    assertThat(result.beRegistries()).singleElement()
+      .satisfies(registry -> assertThat(registry.getHeaders())
+        .containsExactlyEntriesOf(orderedHeaders("X-Okapi-Token", "secret", "X-App", "folio")));
+    verify(log, never()).warn(any(CharSequence.class));
+  }
+
+  @Test
+  void getModuleRegistries_positive_nullConfigHeadersBecomeEmptyMap() {
+    var config = PluginConfig.builder().registries(List.of(okapiConfigRegistry())).build();
+
+    var result = moduleRegistryProvider.getModuleRegistries(config, log);
+
+    assertThat(result.beRegistries()).singleElement()
+      .satisfies(registry -> assertThat(registry.getHeaders()).isEmpty());
+  }
+
+  @Test
+  void getModuleRegistries_positive_dropsHeaderWithUnresolvedValue() {
+    var configRegistry = okapiConfigRegistry();
+    configRegistry.setHeaders(List.of(
+      configHeader("X-Okapi-Token", "${env.EUREKA_HEADER_VALUE}"),
+      configHeader("X-App", "folio")));
+    var config = PluginConfig.builder().registries(List.of(configRegistry)).build();
+
+    var result = moduleRegistryProvider.getModuleRegistries(config, log);
+
+    assertThat(result.beRegistries()).singleElement()
+      .satisfies(registry -> assertThat(registry.getHeaders())
+        .containsExactlyEntriesOf(Map.of("X-App", "folio")));
+    verify(log).warn(contains("Skipping header 'X-Okapi-Token'"));
+  }
+
+  @Test
+  void getModuleRegistries_positive_dropsHeaderWithBlankValue() {
+    var configRegistry = okapiConfigRegistry();
+    configRegistry.setHeaders(List.of(configHeader("X-Okapi-Token", "  ")));
+    var config = PluginConfig.builder().registries(List.of(configRegistry)).build();
+
+    var result = moduleRegistryProvider.getModuleRegistries(config, log);
+
+    assertThat(result.beRegistries()).singleElement()
+      .satisfies(registry -> assertThat(registry.getHeaders()).isEmpty());
+    verify(log).warn(contains("Skipping header 'X-Okapi-Token'"));
+  }
+
+  @Test
+  void getModuleRegistries_positive_dropsHeaderWithUnresolvedName() {
+    var configRegistry = okapiConfigRegistry();
+    configRegistry.setHeaders(List.of(configHeader("${env.EUREKA_HEADER_KEY}", "secret")));
+    var config = PluginConfig.builder().registries(List.of(configRegistry)).build();
+
+    var result = moduleRegistryProvider.getModuleRegistries(config, log);
+
+    assertThat(result.beRegistries()).singleElement()
+      .satisfies(registry -> assertThat(registry.getHeaders()).isEmpty());
+    verify(log).warn(contains("Skipping header"));
   }
 
   @Test
   void getModuleRegistries_negative_unsupportedType() {
     var config = PluginConfig.builder().registries(List.of(unknownModuleRegistry())).build();
 
-    assertThatThrownBy(() -> moduleRegistryProvider.getModuleRegistries(config))
+    assertThatThrownBy(() -> moduleRegistryProvider.getModuleRegistries(config, log))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("""
         Invalid registries found, check documentation at README.md and provided registry list:
@@ -55,7 +131,7 @@ class ModuleRegistryProviderTest {
   void getModuleRegistries_negative_invalidCommandLineRegistry() {
     var config = PluginConfig.builder().cmdRegistryString("unknown::test").build();
 
-    assertThatThrownBy(() -> moduleRegistryProvider.getModuleRegistries(config))
+    assertThatThrownBy(() -> moduleRegistryProvider.getModuleRegistries(config, log))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("""
         Invalid registries found, check documentation at README.md and provided registry list:
@@ -66,7 +142,7 @@ class ModuleRegistryProviderTest {
   void getModuleRegistries_negative_invalidUrl() {
     var config = PluginConfig.builder().registries(List.of(okapiConfigRegistry("unknown-url"))).build();
 
-    assertThatThrownBy(() -> moduleRegistryProvider.getModuleRegistries(config))
+    assertThatThrownBy(() -> moduleRegistryProvider.getModuleRegistries(config, log))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("""
         Invalid registries found, check documentation at README.md and provided registry list:
@@ -79,7 +155,7 @@ class ModuleRegistryProviderTest {
     registry.setType("s3");
     var config = PluginConfig.builder().registries(List.of(registry)).build();
 
-    assertThatThrownBy(() -> moduleRegistryProvider.getModuleRegistries(config))
+    assertThatThrownBy(() -> moduleRegistryProvider.getModuleRegistries(config, log))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("""
         Invalid registries found, check documentation at README.md and provided registry list:
@@ -292,6 +368,21 @@ class ModuleRegistryProviderTest {
     configModuleRegistry.setType("unknown");
     configModuleRegistry.setUrl("https://localhost:8000/registry");
     return configModuleRegistry;
+  }
+
+  private static ConfigHeader configHeader(String name, String value) {
+    var header = new ConfigHeader();
+    header.setName(name);
+    header.setValue(value);
+    return header;
+  }
+
+  private static Map<String, String> orderedHeaders(String... pairs) {
+    var headers = new LinkedHashMap<String, String>();
+    for (int i = 0; i < pairs.length; i += 2) {
+      headers.put(pairs[i], pairs[i + 1]);
+    }
+    return headers;
   }
 
   private static ModuleRegistry okapiRegistry() {

--- a/src/test/java/org/folio/app/generator/service/loader/OkapiModuleDescriptorLoaderTest.java
+++ b/src/test/java/org/folio/app/generator/service/loader/OkapiModuleDescriptorLoaderTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -222,6 +223,38 @@ class OkapiModuleDescriptorLoaderTest {
     verify(log).debug("Retrying request due to status code 504 (attempt 4)");
     verify(log).debug("Retrying request due to status code 504 (attempt 5)");
     verify(log).warn("Failed to load module descriptor 'mod-foo-1.0.0' from http://localhost: 404");
+  }
+
+  @Test
+  void findModuleDescriptor_positive_appliesRegistryHeaders() throws IOException, InterruptedException {
+    ReflectionTestUtils.setField(loader, "httpClient", httpClient);
+    var requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+    when(httpClient.send(requestCaptor.capture(), any())).thenReturn(httpResponse);
+    when(httpResponse.statusCode()).thenReturn(200);
+    mockPayloadResponse(List.of(fooModuleDescriptor("1.0.0")));
+
+    var registry = okapiRegistry("");
+    registry.setHeaders(Map.of("X-Okapi-Token", "secret"));
+
+    var result = loader.findModuleDescriptor(registry, fooModule("1.0.0"));
+
+    assertTrue(result.isPresent());
+    assertThat(requestCaptor.getValue().headers().firstValue("X-Okapi-Token")).contains("secret");
+    verify(log).info("Module descriptor 'mod-foo-1.0.0' loaded from http://localhost");
+  }
+
+  @Test
+  void findModuleDescriptor_positive_noHeadersWhenNotConfigured() throws IOException, InterruptedException {
+    ReflectionTestUtils.setField(loader, "httpClient", httpClient);
+    var requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+    when(httpClient.send(requestCaptor.capture(), any())).thenReturn(httpResponse);
+    when(httpResponse.statusCode()).thenReturn(200);
+    mockPayloadResponse(List.of(fooModuleDescriptor("1.0.0")));
+
+    loader.findModuleDescriptor(okapiRegistry(""), fooModule("1.0.0"));
+
+    assertThat(requestCaptor.getValue().headers().firstValue("X-Okapi-Token")).isEmpty();
+    verify(log).info("Module descriptor 'mod-foo-1.0.0' loaded from http://localhost");
   }
 
   public static Stream<Arguments> statusPathRetryFailSource() {

--- a/src/test/java/org/folio/app/generator/service/parsers/StringModuleRegistryParserTest.java
+++ b/src/test/java/org/folio/app/generator/service/parsers/StringModuleRegistryParserTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.folio.app.generator.model.registry.ModuleRegistry;
@@ -84,8 +85,35 @@ class StringModuleRegistryParserTest {
       arguments("s3::foo-bucket::/foo/bar/", s3ModuleRegistry("foo-bucket", "foo/bar/")),
 
       arguments("s3::test-bucket::/foo/bar/::https://s3-alias.sample/${id}",
-        s3ModuleRegistry("test-bucket", "foo/bar/", "https://s3-alias.sample/${id}"))
+        s3ModuleRegistry("test-bucket", "foo/bar/", "https://s3-alias.sample/${id}")),
+
+      arguments("okapi::http://localhost:3000::headers=X-Okapi-Token:secret",
+        withHeaders(okapiModuleRegistry("http://localhost:3000"), Map.of("X-Okapi-Token", "secret"))),
+      arguments("okapi::http://localhost:3000::headers=X-Okapi-Token:secret;X-App:folio",
+        withHeaders(okapiModuleRegistry("http://localhost:3000"),
+          Map.of("X-Okapi-Token", "secret", "X-App", "folio"))),
+      arguments("okapi::http://localhost:3000::headers=  X-Okapi-Token : secret  ",
+        withHeaders(okapiModuleRegistry("http://localhost:3000"), Map.of("X-Okapi-Token", "secret"))),
+      arguments("okapi::http://localhost:3000::https://test-okapi.sample/${id}::headers=X-Okapi-Token:secret",
+        withHeaders(okapiModuleRegistry("http://localhost:3000", "https://test-okapi.sample/${id}"),
+          Map.of("X-Okapi-Token", "secret"))),
+      arguments("simple::http://localhost:3000::headers=Authorization:Bearer secret-token",
+        withHeaders(simpleModuleRegistry("http://localhost:3000"),
+          Map.of("Authorization", "Bearer secret-token"))),
+      arguments("simple::http://localhost:3000::headers=Authorization:Bearer:multi:colon",
+        withHeaders(simpleModuleRegistry("http://localhost:3000"),
+          Map.of("Authorization", "Bearer:multi:colon"))),
+
+      arguments("okapi::http://localhost:3000::headers=", okapiModuleRegistry("http://localhost:3000")),
+      arguments("okapi::http://localhost:3000::headers=NoColonHeader", okapiModuleRegistry("http://localhost:3000")),
+      arguments("okapi::http://localhost:3000::headers=   :secret", okapiModuleRegistry("http://localhost:3000"))
     );
+  }
+
+  private static ModuleRegistry withHeaders(Object registry, Map<String, String> headers) {
+    var moduleRegistry = (ModuleRegistry) registry;
+    moduleRegistry.getHeaders().putAll(headers);
+    return moduleRegistry;
   }
 
   private static Object okapiModuleRegistry(String url) {

--- a/src/test/java/org/folio/app/generator/service/resolver/OkapiModuleVersionResolverTest.java
+++ b/src/test/java/org/folio/app/generator/service/resolver/OkapiModuleVersionResolverTest.java
@@ -30,6 +30,7 @@ import org.folio.app.generator.utils.JsonConverter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -400,6 +401,25 @@ class OkapiModuleVersionResolverTest {
       .hasMessageContaining("IOException")
       .hasCause(exception);
     verify(log).warn("Failed to fetch versions for module 'mod-foo' from http://localhost", exception);
+  }
+
+  @Test
+  void getAvailableVersions_positive_appliesRegistryHeaders() throws IOException, InterruptedException {
+    var requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+    when(httpClient.send(requestCaptor.capture(), any())).thenReturn(httpResponse);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(IOUtils.toInputStream("", "UTF-8"));
+    when(jsonConverter.parse(any(InputStream.class), any())).thenReturn(List.of(Map.of("id", "mod-foo-1.0.0")));
+
+    var registry = okapiRegistry();
+    registry.setHeaders(Map.of("X-Okapi-Token", "secret"));
+    var dependency = new Dependency("mod-foo", "^1.0.0", PreReleaseFilter.FALSE);
+
+    var result = resolver.getAvailableVersions(registry, dependency, ModuleType.BE);
+
+    assertThat(result).isPresent();
+    assertThat(requestCaptor.getValue().headers().firstValue("X-Okapi-Token")).contains("secret");
+    verify(log).debug("Module 'mod-foo' versions fetched from http://localhost");
   }
 
   private void mockHttpResponse(int statusCode, List<Map<String, Object>> payload)

--- a/src/test/java/org/folio/app/generator/utils/HttpRequestUtilsTest.java
+++ b/src/test/java/org/folio/app/generator/utils/HttpRequestUtilsTest.java
@@ -204,9 +204,9 @@ class HttpRequestUtilsTest {
 
     HttpRequestUtils.applyHeaders(builder, headers);
 
-    var request = builder.GET().build();
-    assertThat(request.headers().firstValue("X-Okapi-Token")).contains("secret");
-    assertThat(request.headers().firstValue("X-App")).contains("folio");
+    var builtRequest = builder.GET().build();
+    assertThat(builtRequest.headers().firstValue("X-Okapi-Token")).contains("secret");
+    assertThat(builtRequest.headers().firstValue("X-App")).contains("folio");
   }
 
   @Test

--- a/src/test/java/org/folio/app/generator/utils/HttpRequestUtilsTest.java
+++ b/src/test/java/org/folio/app/generator/utils/HttpRequestUtilsTest.java
@@ -11,10 +11,13 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.apache.maven.plugin.logging.Log;
 import org.folio.app.generator.support.UnitTest;
 import org.junit.jupiter.api.Test;
@@ -24,7 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-class HttpRetryHelperTest {
+class HttpRequestUtilsTest {
 
   @Mock
   private HttpClient httpClient;
@@ -40,7 +43,7 @@ class HttpRetryHelperTest {
     when(httpClient.send(any(), any())).thenReturn(response);
     when(response.statusCode()).thenReturn(200);
 
-    var result = HttpRetryHelper.sendWithRetry(httpClient, log, request);
+    var result = HttpRequestUtils.sendWithRetry(httpClient, log, request);
 
     assertThat(result).isSameAs(response);
     verify(httpClient, times(1)).send(any(), any());
@@ -53,7 +56,7 @@ class HttpRetryHelperTest {
       .thenReturn(504)
       .thenReturn(200);
 
-    var result = HttpRetryHelper.sendWithRetry(httpClient, log, request);
+    var result = HttpRequestUtils.sendWithRetry(httpClient, log, request);
 
     assertThat(result).isSameAs(response);
     verify(httpClient, times(2)).send(any(), any());
@@ -67,7 +70,7 @@ class HttpRetryHelperTest {
       .thenReturn(response);
     when(response.statusCode()).thenReturn(200);
 
-    var result = HttpRetryHelper.sendWithRetry(httpClient, log, request);
+    var result = HttpRequestUtils.sendWithRetry(httpClient, log, request);
 
     assertThat(result).isSameAs(response);
     verify(httpClient, times(2)).send(any(), any());
@@ -81,7 +84,7 @@ class HttpRetryHelperTest {
       .thenReturn(response);
     when(response.statusCode()).thenReturn(200);
 
-    var result = HttpRetryHelper.sendWithRetry(httpClient, log, request);
+    var result = HttpRequestUtils.sendWithRetry(httpClient, log, request);
 
     assertThat(result).isSameAs(response);
     verify(httpClient, times(2)).send(any(), any());
@@ -95,7 +98,7 @@ class HttpRetryHelperTest {
       .thenReturn(response);
     when(response.statusCode()).thenReturn(200);
 
-    var result = HttpRetryHelper.sendWithRetry(httpClient, log, request);
+    var result = HttpRequestUtils.sendWithRetry(httpClient, log, request);
 
     assertThat(result).isSameAs(response);
     verify(httpClient, times(2)).send(any(), any());
@@ -111,7 +114,7 @@ class HttpRetryHelperTest {
       .thenReturn(response);
     when(response.statusCode()).thenReturn(200);
 
-    var result = HttpRetryHelper.sendWithRetry(httpClient, log, request);
+    var result = HttpRequestUtils.sendWithRetry(httpClient, log, request);
 
     assertThat(result).isSameAs(response);
     verify(log).warn("Network error, retrying (attempt 1): SocketException");
@@ -122,7 +125,7 @@ class HttpRetryHelperTest {
     var exception = new SocketException("Connection refused");
     when(httpClient.send(any(), any())).thenThrow(exception);
 
-    assertThatThrownBy(() -> HttpRetryHelper.sendWithRetry(httpClient, log, request))
+    assertThatThrownBy(() -> HttpRequestUtils.sendWithRetry(httpClient, log, request))
       .isInstanceOf(SocketException.class)
       .hasMessage("Connection refused");
 
@@ -142,7 +145,7 @@ class HttpRetryHelperTest {
       .thenReturn(504).thenReturn(504)
       .thenReturn(504).thenReturn(200);
 
-    var result = HttpRetryHelper.sendWithRetry(httpClient, log, request);
+    var result = HttpRequestUtils.sendWithRetry(httpClient, log, request);
 
     assertThat(result).isSameAs(response);
     verify(httpClient, times(6)).send(any(), any());
@@ -158,7 +161,7 @@ class HttpRetryHelperTest {
       .thenReturn(504)
       .thenReturn(200);
 
-    var result = HttpRetryHelper.sendWithRetry(httpClient, log, request);
+    var result = HttpRequestUtils.sendWithRetry(httpClient, log, request);
 
     assertThat(result).isSameAs(response);
     verify(httpClient, times(5)).send(any(), any());
@@ -166,29 +169,61 @@ class HttpRetryHelperTest {
 
   @Test
   void cleanUrl_removesTrailingSlash() {
-    var result = HttpRetryHelper.cleanUrl("http://example.com/");
+    var result = HttpRequestUtils.cleanUrl("http://example.com/");
 
     assertThat(result).isEqualTo("http://example.com");
   }
 
   @Test
   void cleanUrl_noChangeWithoutTrailingSlash() {
-    var result = HttpRetryHelper.cleanUrl("http://example.com");
+    var result = HttpRequestUtils.cleanUrl("http://example.com");
 
     assertThat(result).isEqualTo("http://example.com");
   }
 
   @Test
   void cleanUrl_handlesMultiplePathSegments() {
-    var result = HttpRetryHelper.cleanUrl("http://example.com/api/v1/");
+    var result = HttpRequestUtils.cleanUrl("http://example.com/api/v1/");
 
     assertThat(result).isEqualTo("http://example.com/api/v1");
   }
 
   @Test
   void constants_haveExpectedValues() {
-    assertThat(HttpRetryHelper.RETRYABLE_STATUS_CODES).containsExactlyInAnyOrder(429, 500, 502, 503, 504);
-    assertThat(HttpRetryHelper.RETRYABLE_ATTEMPTS_NUMBER).isEqualTo(5);
-    assertThat(HttpRetryHelper.RETRY_DELAY_MS).isEqualTo(1000);
+    assertThat(HttpRequestUtils.RETRYABLE_STATUS_CODES).containsExactlyInAnyOrder(429, 500, 502, 503, 504);
+    assertThat(HttpRequestUtils.RETRYABLE_ATTEMPTS_NUMBER).isEqualTo(5);
+    assertThat(HttpRequestUtils.RETRY_DELAY_MS).isEqualTo(1000);
+  }
+
+  @Test
+  void applyHeaders_positive_addsAllHeaders() {
+    var builder = HttpRequest.newBuilder().uri(URI.create("http://example.com"));
+    var headers = new LinkedHashMap<String, String>();
+    headers.put("X-Okapi-Token", "secret");
+    headers.put("X-App", "folio");
+
+    HttpRequestUtils.applyHeaders(builder, headers);
+
+    var request = builder.GET().build();
+    assertThat(request.headers().firstValue("X-Okapi-Token")).contains("secret");
+    assertThat(request.headers().firstValue("X-App")).contains("folio");
+  }
+
+  @Test
+  void applyHeaders_positive_nullHeadersAddsNothing() {
+    var builder = HttpRequest.newBuilder().uri(URI.create("http://example.com"));
+
+    HttpRequestUtils.applyHeaders(builder, null);
+
+    assertThat(builder.GET().build().headers().map()).isEmpty();
+  }
+
+  @Test
+  void applyHeaders_positive_emptyHeadersAddsNothing() {
+    var builder = HttpRequest.newBuilder().uri(URI.create("http://example.com"));
+
+    HttpRequestUtils.applyHeaders(builder, Map.of());
+
+    assertThat(builder.GET().build().headers().map()).isEmpty();
   }
 }

--- a/src/test/java/org/folio/app/generator/utils/RegistryHeaderParserTest.java
+++ b/src/test/java/org/folio/app/generator/utils/RegistryHeaderParserTest.java
@@ -1,0 +1,109 @@
+package org.folio.app.generator.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.folio.app.generator.model.types.RegistryType;
+import org.folio.app.generator.support.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class RegistryHeaderParserTest {
+
+  @Test
+  void parseHeaders_singleHeader() {
+    assertThat(RegistryHeaderParser.parseHeaders("X-Okapi-Token:secret"))
+      .containsExactlyEntriesOf(Map.of("X-Okapi-Token", "secret"));
+  }
+
+  @Test
+  void parseHeaders_multipleHeaders() {
+    var result = RegistryHeaderParser.parseHeaders("X-Okapi-Token:secret;X-App:folio");
+    assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of("X-Okapi-Token", "secret", "X-App", "folio"));
+  }
+
+  @Test
+  void parseHeaders_valueWithColonsKeptAfterFirstSplit() {
+    assertThat(RegistryHeaderParser.parseHeaders("Authorization:Bearer:multi:colon"))
+      .containsExactlyEntriesOf(Map.of("Authorization", "Bearer:multi:colon"));
+  }
+
+  @Test
+  void parseHeaders_trimsWhitespace() {
+    assertThat(RegistryHeaderParser.parseHeaders("  X-Okapi-Token : secret  "))
+      .containsExactlyEntriesOf(Map.of("X-Okapi-Token", "secret"));
+  }
+
+  @Test
+  void parseHeaders_skipsMalformedEntries() {
+    var result = RegistryHeaderParser.parseHeaders("NoColon;:blankName;X-Ok:v");
+    assertThat(result).containsExactlyEntriesOf(Map.of("X-Ok", "v"));
+  }
+
+  @Test
+  void parseHeaders_blankReturnsEmpty() {
+    assertThat(RegistryHeaderParser.parseHeaders("   ")).isEmpty();
+    assertThat(RegistryHeaderParser.parseHeaders(null)).isEmpty();
+  }
+
+  @Test
+  void parseScoped_blankIsEmpty() {
+    var scoped = RegistryHeaderParser.parseScoped("  ");
+    assertThat(scoped.isEmpty()).isTrue();
+    assertThat(scoped.forType(RegistryType.OKAPI)).isEmpty();
+  }
+
+  @Test
+  void parseScoped_globalAppliesToEveryType() {
+    var scoped = RegistryHeaderParser.parseScoped("X-Okapi-Token:secret;X-App:folio");
+
+    assertThat(scoped.global()).containsExactlyInAnyOrderEntriesOf(
+      Map.of("X-Okapi-Token", "secret", "X-App", "folio"));
+    assertThat(scoped.forType(RegistryType.OKAPI))
+      .containsExactlyInAnyOrderEntriesOf(Map.of("X-Okapi-Token", "secret", "X-App", "folio"));
+    assertThat(scoped.forType(RegistryType.SIMPLE))
+      .containsExactlyInAnyOrderEntriesOf(Map.of("X-Okapi-Token", "secret", "X-App", "folio"));
+  }
+
+  @Test
+  void parseScoped_typePrefixAppliesOnlyToThatType() {
+    var scoped = RegistryHeaderParser.parseScoped("okapi::X-Okapi-Token:secret");
+
+    assertThat(scoped.global()).isEmpty();
+    assertThat(scoped.forType(RegistryType.OKAPI)).containsExactlyEntriesOf(Map.of("X-Okapi-Token", "secret"));
+    assertThat(scoped.forType(RegistryType.SIMPLE)).isEmpty();
+  }
+
+  @Test
+  void parseScoped_mixedGlobalAndTypeScoped() {
+    var scoped = RegistryHeaderParser.parseScoped("X-App:folio,okapi::X-Okapi-Token:secret");
+
+    assertThat(scoped.forType(RegistryType.OKAPI))
+      .containsExactlyInAnyOrderEntriesOf(Map.of("X-App", "folio", "X-Okapi-Token", "secret"));
+    assertThat(scoped.forType(RegistryType.SIMPLE)).containsExactlyEntriesOf(Map.of("X-App", "folio"));
+  }
+
+  @Test
+  void parseScoped_typeSpecificOverridesGlobalForSameName() {
+    var scoped = RegistryHeaderParser.parseScoped("X-Token:global,okapi::X-Token:scoped");
+
+    assertThat(scoped.forType(RegistryType.OKAPI)).containsExactlyEntriesOf(Map.of("X-Token", "scoped"));
+    assertThat(scoped.forType(RegistryType.SIMPLE)).containsExactlyEntriesOf(Map.of("X-Token", "global"));
+  }
+
+  @Test
+  void parseScoped_unknownPrefixTreatedAsGlobalHeaderWithColonValue() {
+    var scoped = RegistryHeaderParser.parseScoped("Authorization:Bearer::x");
+
+    assertThat(scoped.global()).containsExactlyEntriesOf(Map.of("Authorization", "Bearer::x"));
+  }
+
+  @Test
+  void parseScoped_ignoresEmptyGroups() {
+    var scoped = RegistryHeaderParser.parseScoped(",X-App:folio, ,okapi::X-Okapi-Token:secret,");
+
+    assertThat(scoped.forType(RegistryType.OKAPI))
+      .containsExactlyInAnyOrderEntriesOf(Map.of("X-App", "folio", "X-Okapi-Token", "secret"));
+    assertThat(scoped.forType(RegistryType.SIMPLE)).containsExactlyEntriesOf(Map.of("X-App", "folio"));
+  }
+}


### PR DESCRIPTION
## Purpose

[APPDESCRIP-74](https://folio-org.atlassian.net/browse/APPDESCRIP-74)

FOLIO module registries (e.g. `folio-registry.dev.folio.org`) requires an additional security header
on inbound requests. The application generator currently has no way to
attach a custom HTTP header to the requests it makes when resolving module descriptors and versions,
so against a Eureka-protected registry those requests are rejected.

This change lets each module registry carry one or more custom HTTP headers, whose **name and value**
can be injected at build time from org-level GitHub secrets via standard Maven property / `${env.*}`
interpolation. Headers are **scoped to the specific registry** they are configured on, so a secret is
never broadcast to other or external hosts.

## Approach

**Per-registry, not global.** A header belongs to a single registry definition, so the secret stays
scoped to the host it is meant for. Headers are applied only to **Okapi** and **Simple** (HTTP)
module registries — both at module-descriptor loading and at version resolution. S3 registries use
the AWS SDK rather than `HttpClient`, so they carry the field for model uniformity but ignore it;
artifact-existence checks (DockerHub/NPM/ECR), which hit external public hosts, are untouched.

**Three ways to configure headers:**

- **pom.xml (recommended for CI secrets)** — a `<headers>` block of `<header><name>/<value></header>`
  entries. Because both are XML element *values* (not element names), both interpolate from Maven
  properties and the environment, so a secret header name *and* value can be supplied with no
  command-line arguments and no per-build pom edits:

  ```xml
  <moduleRegistries>
    <registry>
      <type>okapi</type>
      <url>https://folio-registry.dev.folio.org</url>
      <headers>
        <header>
          <name>${env.HEADER_KEY}</name>
          <value>${env.HEADER_VALUE}</value>
        </header>
      </headers>
    </registry>
  </moduleRegistries>
  ```

  ```yaml
  # workflow: map org secrets to the job environment; nothing on the mvn line
  env:
    HEADER_KEY:   ${{ secrets.HEADER_KEY }}
    HEADER_VALUE: ${{ secrets.HEADER_VALUE }}
  steps:
    - run: mvn org.folio:folio-application-generator:generateFromConfiguration
  ```

- **Command line (per registry)** — an optional `::headers=Name:Value;Name2:Value2` suffix on the
  registry string (multiple headers separated by `;`; only the first `:` splits name from value, so
  values may contain `:`).

- **`registryHeaders` parameter (applies to pom-defined registries without restating them)** — attaches
  headers to the registries **already configured in the pom**, without listing them again or editing
  each pom. One value expresses global or per-type scope:
  `-DregistryHeaders="X-Okapi-Token:secret"` (all module registries),
  `-DregistryHeaders="okapi::X-Okapi-Token:secret"` (only `okapi`), or a mix with comma-separated
  groups: `-DregistryHeaders="X-App:folio,okapi::X-Okapi-Token:secret"`. A header already set on a
  registry (via its pom `<headers>` / `::headers=`) is **not** overridden — per-registry config wins.

  This is the **cross-version-safe** way to roll a header out from a shared workflow/action: an unknown
  `-D` system property is silently ignored by older plugin versions (verified against a pre-feature
  release), whereas adding a pom `<headers>` element *fails the build* on versions that predate this
  feature. So a shared action can pass `-DregistryHeaders` unconditionally — consumers on a new plugin
  version apply it, consumers still on an older version are unaffected — while registries stay solely
  in each app's pom.

**Missing/empty-secret guard.** When a secret is unset, Maven leaves the literal `${...}` placeholder;
when empty, it resolves to `""`. A single sanitation pass in `ModuleRegistryProvider` drops any header
(from any of the three paths) whose name or value is blank or still contains `${`, logs a warning
identifying the registry and header, and lets generation continue. The result: no malformed header is
ever sent, the build does not fail on a missing secret, and any downstream failure surfaces as a
normal "module not found" rather than a cryptic error.

**Where the header is applied.** The shared `java.net.http.HttpClient` bean does not support default
headers, so headers are added per `HttpRequest`. A small `HttpRequestUtils.applyHeaders(builder, map)`
helper is used at the four request-build sites: `OkapiModuleDescriptorLoader`,
`SimpleModuleDescriptorLoader`, `OkapiModuleVersionResolver`, `SimpleModuleVersionResolver`.

**Incidental cleanups made along the way:**

- Renamed `HttpRetryHelper` → `HttpRequestUtils` (it now also hosts `applyHeaders` and the existing
  `cleanUrl`; the old name no longer described its contents).
- Extracted the `Name:Value;…` header parsing into a reusable `RegistryHeaderParser` util, shared by
  the per-registry `::headers=` path and the global `registryHeaders` parameter (which adds the
  `type::` / comma-group grammar on top).
- Kept `ModuleRegistry` accessor-only: `getHeaders()` was added as a read accessor, while header
  *setting* is done on the concrete registries (the parser builds each registry via its factory), so
  the interface gains no mutator.
