### PR TITLE
APPDESCRIP-71. Add ECR artifact validation and skip flags for custom modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,9 +337,11 @@ This command will generate application on a fly and validates the application's 
 
 ### Validate Module Artifacts Existence
 
-The `validateArtifacts` parameter enables validation of module artifacts in Docker and NPM registries before generating the application descriptor. When enabled, the plugin verifies that:
-- Backend (BE) modules have corresponding Docker images in the configured Docker registries
+The `validateArtifacts` parameter enables validation of module artifacts in Docker, AWS ECR, and NPM registries before generating the application descriptor. When enabled, the plugin verifies that:
+- Backend (BE) modules have corresponding Docker images in the configured Docker Hub or AWS ECR registries
 - Frontend (UI) modules have corresponding NPM packages in the configured NPM registries
+
+Supported artifact registry types: `docker-hub`, `aws-ecr`, `folio-npm`.
 
 #### Default Registries
 
@@ -392,21 +394,39 @@ Or via pom.xml configuration:
 
 #### Custom Registries
 
-Custom artifact registries can be specified via command-line:
+Each command-line entry uses a `<type>::` prefix to identify its registry type. Supported prefixes:
+
+| Prefix         | Format                                  | Notes |
+|----------------|-----------------------------------------|-------|
+| `docker-hub::` | `docker-hub::[<baseUrl>::]<namespace>`  | `baseUrl` optional; defaults to Docker Hub v2 API |
+| `aws-ecr::`    | `aws-ecr::<baseUrl>[::<namespace>]`     | `baseUrl` required; must be a valid ECR endpoint (`https://<account>.dkr.ecr.<region>.amazonaws.com`). Authenticates via the default AWS credential chain (same as the existing S3 client). |
+| `folio-npm::`  | `folio-npm::[<baseUrl>::]<namespace>`   | `baseUrl` optional; defaults to Folio Nexus repository |
+
+Category-level rules: `beArtifactRegistries` / `bePreReleaseArtifactRegistries` accept `docker-hub::` and `aws-ecr::` entries; `uiArtifactRegistries` / `uiPreReleaseArtifactRegistries` accept `folio-npm::`; `artifactRegistries` accepts all three.
+
+> **Breaking change (1.6.0):** The artifact-registry command-line grammar now requires the `<type>::` prefix. Bare-namespace strings (e.g., `-DbeArtifactRegistries="folioorg"`) are no longer accepted. Update CI scripts to include the prefix.
+
 ```shell
 mvn org.folio:folio-application-generator:generateFromJson \
   -DvalidateArtifacts=true \
-  -DbeArtifactRegistries="folioorg" \
-  -DbePreReleaseArtifactRegistries="folioci" \
-  -DuiArtifactRegistries="npm-folio" \
-  -DuiPreReleaseArtifactRegistries="npm-folioci"
+  -DbeArtifactRegistries="docker-hub::folioorg" \
+  -DbePreReleaseArtifactRegistries="docker-hub::folioci" \
+  -DuiArtifactRegistries="folio-npm::npm-folio" \
+  -DuiPreReleaseArtifactRegistries="folio-npm::npm-folioci"
 ```
 
-For custom registry URLs:
+For mixed Docker Hub + ECR:
 ```shell
 mvn org.folio:folio-application-generator:generateFromJson \
   -DvalidateArtifacts=true \
-  -DbeArtifactRegistries="https://private-registry.io/v2::my-namespace"
+  -DbeArtifactRegistries="docker-hub::folioorg,aws-ecr::https://123456789012.dkr.ecr.us-west-2.amazonaws.com::folio"
+```
+
+For private Docker Hub-compatible registries:
+```shell
+mvn org.folio:folio-application-generator:generateFromJson \
+  -DvalidateArtifacts=true \
+  -DbeArtifactRegistries="docker-hub::https://private-registry.io/v2::my-namespace"
 ```
 
 Or via pom.xml configuration:
@@ -414,11 +434,16 @@ Or via pom.xml configuration:
 <configuration>
   <validateArtifacts>true</validateArtifacts>
 
-  <!-- BE release registries -->
+  <!-- BE release registries (docker-hub and/or aws-ecr) -->
   <beArtifactRegistries>
     <registry>
       <type>docker-hub</type>
       <namespace>folioorg</namespace>
+    </registry>
+    <registry>
+      <type>aws-ecr</type>
+      <baseUrl>https://123456789012.dkr.ecr.us-west-2.amazonaws.com</baseUrl>
+      <namespace>folio</namespace>
     </registry>
   </beArtifactRegistries>
 
@@ -430,7 +455,7 @@ Or via pom.xml configuration:
     </registry>
   </bePreReleaseArtifactRegistries>
 
-  <!-- UI release registries -->
+  <!-- UI release registries (folio-npm only) -->
   <uiArtifactRegistries>
     <registry>
       <type>folio-npm</type>
@@ -446,6 +471,22 @@ Or via pom.xml configuration:
     </registry>
   </uiPreReleaseArtifactRegistries>
 </configuration>
+```
+
+#### Skipping Artifact Validation for Fallback Registries
+
+The `validateFallbackArtifacts` parameter (default `true`) controls whether modules resolved through fallback descriptor registries are still validated against artifact registries. Set it to `false` for builds that include custom modules whose artifacts are not published to any configured registry (typical for custom UI modules referenced via npm git refs, or BE modules whose images are not available in the configured ECR/Docker Hub).
+
+Semantics:
+- `validateArtifacts=false` → nothing is validated (no change to existing behavior).
+- `validateArtifacts=true` and `validateFallbackArtifacts=true` (defaults) → both primary and fallback modules are artifact-validated.
+- `validateArtifacts=true` and `validateFallbackArtifacts=false` → modules resolved from primary registries are validated; modules resolved from fallback registries skip artifact validation.
+
+```shell
+mvn org.folio:folio-application-generator:generateFromJson \
+  -DvalidateArtifacts=true \
+  -DvalidateFallbackArtifacts=false \
+  -DbeFallbackRegistries="s3::eureka-custom-registry::descriptors"
 ```
 
 #### Unified Artifact Registries
@@ -665,15 +706,16 @@ mvn install -DbuildNumber="123" -DawsRegion=us-east-1
 | modules                        |                                                 | Comma-separated list of BE module ids to be updated in format: `module1-1.1.0,module2-2.1.0`                                                                        |
 | uiModules                      |                                                 | Comma-separated list of UI module ids to be updated in the same format as `modules` parameter                                                                       |
 | overrideConfigRegistries       |                                                 | Defines if only command-line specified registries must be used (applies to `registries`, `beRegistries` and `uiRegistries` params)                                  |
+| validateArtifacts              | false                                           | Enable validation of module artifacts in configured artifact registries before generating the descriptor                                                            |
+| validateFallbackArtifacts      | true                                            | When `false`, modules resolved from fallback descriptor registries skip artifact validation. Only applies when `validateArtifacts=true`                             |
+| artifactRegistries             |                                                 | Comma-separated unified artifact registry list; entries use type-prefix grammar: `docker-hub::[<baseUrl>::]<namespace>`, `aws-ecr::<baseUrl>[::<namespace>]`, `folio-npm::[<baseUrl>::]<namespace>` |
+| beArtifactRegistries           |                                                 | BE-only artifact registries; entries must be `docker-hub::...` or `aws-ecr::...` (same format as `artifactRegistries`)                                              |
+| bePreReleaseArtifactRegistries |                                                 | BE-only pre-release artifact registries; same format as `beArtifactRegistries`                                                                                      |
+| uiArtifactRegistries           |                                                 | UI-only artifact registries; entries must be `folio-npm::...` (same format as `artifactRegistries`)                                                                 |
+| uiPreReleaseArtifactRegistries |                                                 | UI-only pre-release artifact registries; same format as `uiArtifactRegistries`                                                                                      |
 | allowDowngrade                 | false                                           | Allow downgrading module versions during update (applies to `updateFromJson` and `updateFromTemplate` goals)                                                        |
 | allowAddModules                | false                                           | Allow adding new modules not present in the original descriptor (applies to `updateFromJson` and `updateFromTemplate` goals)                                        |
 | removeUnlistedModules          | false                                           | Remove modules from descriptor that are not in the update list/template (applies to `updateFromJson` and `updateFromTemplate` goals)                                |
 | templatePath                   | `${project.artifactId}.template.json`           | Path to the template file for `updateFromTemplate` goal                                                                                                             |
 | useProjectVersion              | false                                           | When `true`, uses pom.xml version as base; when `false`, increments patch from descriptor version (applies to `updateFromJson` and `updateFromTemplate` goals)     |
 | noVersionBump                  | false                                           | Skip automatic version incrementing, keeping the version unchanged (applies to `updateFromJson` and `updateFromTemplate` goals)                                    |
-| validateArtifacts              | false                                           | If `true`, validates that Docker images (BE) and NPM packages (UI) exist before generating the descriptor                                                           |
-| artifactRegistries             |                                                 | Comma-separated unified artifact registries (fallback for both BE and UI)                                                                                           |
-| beArtifactRegistries           |                                                 | Comma-separated BE artifact registries for release versions (format: `namespace` or `url::namespace`)                                                               |
-| uiArtifactRegistries           |                                                 | Comma-separated UI artifact registries for release versions (format: `repository` or `url::repository`)                                                             |
-| bePreReleaseArtifactRegistries |                                                 | Comma-separated BE artifact registries for pre-release versions                                                                                                     |
-| uiPreReleaseArtifactRegistries |                                                 | Comma-separated UI artifact registries for pre-release versions                                                                                                     |

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,12 @@
     </dependency>
 
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>ecr</artifactId>
+      <version>${aws-sdk.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>localstack</artifactId>
       <version>${testcontainers.version}</version>

--- a/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
+++ b/src/main/java/org/folio/app/generator/AbstractGeneratorMojo.java
@@ -85,6 +85,9 @@ public abstract class AbstractGeneratorMojo extends AbstractMojo {
   @Parameter(name = "validateArtifacts", property = "validateArtifacts", defaultValue = "false")
   protected String validateArtifacts;
 
+  @Parameter(name = "validateFallbackArtifacts", property = "validateFallbackArtifacts", defaultValue = "true")
+  protected String validateFallbackArtifacts;
+
   @Parameter(name = "artifactRegistries")
   protected List<ConfigArtifactRegistry> artifactRegistries;
 
@@ -144,6 +147,7 @@ public abstract class AbstractGeneratorMojo extends AbstractMojo {
       .registryHeaders(registryHeaders)
       .awsRegion(isNotBlank(awsRegion) ? Region.of(awsRegion) : Region.US_EAST_1)
       .validateArtifacts(parseBoolean(validateArtifacts))
+      .validateFallbackArtifacts(parseBoolean(validateFallbackArtifacts))
       .artifactRegistries(artifactRegistries)
       .beArtifactRegistries(beArtifactRegistries)
       .uiArtifactRegistries(uiArtifactRegistries)

--- a/src/main/java/org/folio/app/generator/conditions/ArtifactValidationCondition.java
+++ b/src/main/java/org/folio/app/generator/conditions/ArtifactValidationCondition.java
@@ -4,13 +4,14 @@ import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.context.annotation.Conditional;
 
 /**
- * Condition that matches when any artifact validation is enabled. This condition is true if either Docker Hub or Folio
- * NPM artifact validation is enabled.
+ * Condition that matches when any artifact validation is enabled. This condition is true if Docker Hub, Folio NPM, or
+ * AWS ECR artifact validation is enabled.
  *
  * <p>This is a composite condition that checks:
  * <ul>
  *   <li>{@code folio-app-generator.docker-hub.enabled} (via {@link DockerHubCondition})</li>
  *   <li>{@code folio-app-generator.folio-npm.enabled} (via {@link FolioNpmCondition})</li>
+ *   <li>{@code folio-app-generator.aws-ecr.enabled} (via {@link EcrCondition})</li>
  * </ul>
  */
 public class ArtifactValidationCondition extends AnyNestedCondition {
@@ -24,4 +25,7 @@ public class ArtifactValidationCondition extends AnyNestedCondition {
 
   @Conditional(FolioNpmCondition.class)
   static class FolioNpm {}
+
+  @Conditional(EcrCondition.class)
+  static class Ecr {}
 }

--- a/src/main/java/org/folio/app/generator/conditions/EcrCondition.java
+++ b/src/main/java/org/folio/app/generator/conditions/EcrCondition.java
@@ -1,0 +1,21 @@
+package org.folio.app.generator.conditions;
+
+import static org.folio.app.generator.model.types.ArtifactRegistryType.AWS_ECR;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition that matches when AWS ECR artifact validation is enabled.
+ *
+ * <p>This condition checks the system property: {@code folio-app-generator.aws-ecr.enabled}
+ */
+public class EcrCondition implements Condition {
+
+  @Override
+  public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    var ecrEnabled = context.getEnvironment().getProperty(AWS_ECR.getPropertyName());
+    return Boolean.parseBoolean(ecrEnabled);
+  }
+}

--- a/src/main/java/org/folio/app/generator/configuration/SpringConfiguration.java
+++ b/src/main/java/org/folio/app/generator/configuration/SpringConfiguration.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import org.folio.app.generator.conditions.AwsCondition;
+import org.folio.app.generator.conditions.EcrCondition;
 import org.folio.app.generator.conditions.HttpCondition;
 import org.folio.app.generator.utils.PluginConfig;
 import org.springframework.context.annotation.Bean;
@@ -12,6 +13,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.services.ecr.EcrClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
@@ -45,5 +47,14 @@ public class SpringConfiguration {
     }
 
     return builder.build();
+  }
+
+  @Bean(name = "ecrClient")
+  @Conditional(EcrCondition.class)
+  public EcrClient ecrClient(PluginConfig config) {
+    return EcrClient.builder()
+      .region(config.getAwsRegion())
+      .credentialsProvider(DefaultCredentialsProvider.create())
+      .build();
   }
 }

--- a/src/main/java/org/folio/app/generator/model/registry/ModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/ModuleRegistry.java
@@ -51,4 +51,22 @@ public interface ModuleRegistry {
    * @return registry identifier (e.g., URL for Okapi/Simple, bucket/path for S3)
    */
   String getRegistryIdentifier();
+
+  /**
+   * Indicates whether this registry instance is used as a fallback source.
+   *
+   * <p>Fallback registries are consulted only when a module cannot be resolved from the primary registries.
+   * The flag is also consulted by artifact validation: when {@code validateFallbackArtifacts} is {@code false},
+   * candidates produced from a fallback registry bypass artifact existence checks.</p>
+   *
+   * @return {@code true} if this registry is used as fallback, {@code false} otherwise
+   */
+  boolean isFallback();
+
+  /**
+   * Marks this registry instance as a fallback source.
+   *
+   * @param fallback {@code true} to mark this registry as fallback
+   */
+  void setFallback(boolean fallback);
 }

--- a/src/main/java/org/folio/app/generator/model/registry/OkapiModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/OkapiModuleRegistry.java
@@ -20,6 +20,7 @@ public class OkapiModuleRegistry implements ModuleRegistry {
   private String url;
   private String publicUrl;
   private Map<String, String> headers = new LinkedHashMap<>();
+  private boolean fallback;
 
   /**
    * Sets url field and returns {@link OkapiModuleRegistry}.

--- a/src/main/java/org/folio/app/generator/model/registry/S3ModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/S3ModuleRegistry.java
@@ -20,6 +20,7 @@ public class S3ModuleRegistry implements ModuleRegistry {
   private String bucket;
   private String publicUrl;
   private Map<String, String> headers = new LinkedHashMap<>();
+  private boolean fallback;
 
   /**
    * Sets path field and returns {@link S3ModuleRegistry}.

--- a/src/main/java/org/folio/app/generator/model/registry/SimpleModuleRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/SimpleModuleRegistry.java
@@ -21,6 +21,7 @@ public class SimpleModuleRegistry implements ModuleRegistry {
   private String url;
   private String publicUrl;
   private Map<String, String> headers = new LinkedHashMap<>();
+  private boolean fallback;
 
   /**
    * Sets url field and returns {@link SimpleModuleRegistry}.

--- a/src/main/java/org/folio/app/generator/model/registry/artifact/EcrArtifactRegistry.java
+++ b/src/main/java/org/folio/app/generator/model/registry/artifact/EcrArtifactRegistry.java
@@ -1,0 +1,36 @@
+package org.folio.app.generator.model.registry.artifact;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import lombok.EqualsAndHashCode;
+import org.folio.app.generator.model.types.ArtifactRegistryType;
+
+@EqualsAndHashCode(callSuper = true)
+public class EcrArtifactRegistry extends AbstractArtifactRegistry<EcrArtifactRegistry> {
+
+  private static final ArtifactRegistryType TYPE = ArtifactRegistryType.AWS_ECR;
+
+  public EcrArtifactRegistry() {
+    super(null);
+  }
+
+  @Override
+  public ArtifactRegistryType getType() {
+    return TYPE;
+  }
+
+  @Override
+  public boolean isValid() {
+    if (isBlank(baseUrl)) {
+      return false;
+    }
+    try {
+      new URL(baseUrl);
+      return true;
+    } catch (MalformedURLException e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/org/folio/app/generator/model/types/ArtifactRegistryType.java
+++ b/src/main/java/org/folio/app/generator/model/types/ArtifactRegistryType.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum ArtifactRegistryType {
 
   DOCKER_HUB("docker-hub", "folio-app-generator.docker-hub.enabled"),
-  FOLIO_NPM("folio-npm", "folio-app-generator.folio-npm.enabled");
+  FOLIO_NPM("folio-npm", "folio-app-generator.folio-npm.enabled"),
+  AWS_ECR("aws-ecr", "folio-app-generator.aws-ecr.enabled");
 
   private final String value;
   private final String propertyName;

--- a/src/main/java/org/folio/app/generator/service/ArtifactRegistryProvider.java
+++ b/src/main/java/org/folio/app/generator/service/ArtifactRegistryProvider.java
@@ -145,7 +145,7 @@ public class ArtifactRegistryProvider {
           continue;
         }
         var registry = parsed.get();
-        if (!allowedTypes.contains(registry.getType()) || !registry.isValid()) {
+        if (!allowedTypes.contains(registry.getType())) {
           invalid.add(value);
         } else {
           result.add(registry);

--- a/src/main/java/org/folio/app/generator/service/ArtifactRegistryProvider.java
+++ b/src/main/java/org/folio/app/generator/service/ArtifactRegistryProvider.java
@@ -17,6 +17,7 @@ import org.folio.app.generator.model.registry.artifact.ArtifactRegistries;
 import org.folio.app.generator.model.registry.artifact.ArtifactRegistry;
 import org.folio.app.generator.model.registry.artifact.ConfigArtifactRegistry;
 import org.folio.app.generator.model.registry.artifact.DockerHubArtifactRegistry;
+import org.folio.app.generator.model.registry.artifact.EcrArtifactRegistry;
 import org.folio.app.generator.model.registry.artifact.FolioNpmArtifactRegistry;
 import org.folio.app.generator.model.types.ArtifactRegistryType;
 import org.folio.app.generator.service.parsers.StringArtifactRegistryParser;
@@ -27,9 +28,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor(onConstructor = @__(@Inject))
 public class ArtifactRegistryProvider {
 
+  private static final List<ArtifactRegistryType> BE_ALLOWED_TYPES =
+    List.of(ArtifactRegistryType.DOCKER_HUB, ArtifactRegistryType.AWS_ECR);
+  private static final List<ArtifactRegistryType> UI_ALLOWED_TYPES =
+    List.of(ArtifactRegistryType.FOLIO_NPM);
+  private static final List<ArtifactRegistryType> UNIFIED_ALLOWED_TYPES =
+    List.of(ArtifactRegistryType.DOCKER_HUB, ArtifactRegistryType.AWS_ECR, ArtifactRegistryType.FOLIO_NPM);
+
   private final StringArtifactRegistryParser artifactRegistryParser;
-  private final List<String> supportedDockerTypes = List.of(ArtifactRegistryType.DOCKER_HUB.getValue());
-  private final List<String> supportedNpmTypes = List.of(ArtifactRegistryType.FOLIO_NPM.getValue());
 
   public ArtifactRegistries getArtifactRegistries(PluginConfig config) {
     var processor = new ArtifactRegistryProcessor(config);
@@ -51,12 +57,24 @@ public class ArtifactRegistryProvider {
   }
 
   private static ArtifactRegistry toArtifactRegistry(ConfigArtifactRegistry registry) {
-    if (ArtifactRegistryType.DOCKER_HUB.getValue().equals(lowerCase(registry.getType()))) {
+    var type = lowerCase(registry.getType());
+    if (ArtifactRegistryType.DOCKER_HUB.getValue().equals(type)) {
       var dockerRegistry = new DockerHubArtifactRegistry().namespace(registry.getNamespace());
       if (isNotBlank(registry.getBaseUrl())) {
         dockerRegistry.baseUrl(registry.getBaseUrl());
       }
       return dockerRegistry;
+    }
+
+    if (ArtifactRegistryType.AWS_ECR.getValue().equals(type)) {
+      var ecrRegistry = new EcrArtifactRegistry();
+      if (isNotBlank(registry.getBaseUrl())) {
+        ecrRegistry.baseUrl(registry.getBaseUrl());
+      }
+      if (isNotBlank(registry.getNamespace())) {
+        ecrRegistry.namespace(registry.getNamespace());
+      }
+      return ecrRegistry;
     }
 
     var npmRegistry = new FolioNpmArtifactRegistry().namespace(registry.getNamespace());
@@ -84,79 +102,71 @@ public class ArtifactRegistryProvider {
 
     ArtifactRegistryProcessor(PluginConfig config) {
       this.invalidRegistries = new ArrayList<>();
-      this.unifiedRegistries = new ArrayList<>(processUnifiedRegistries(config));
-      this.beRegistries = new ArrayList<>(processBeRegistries(config));
-      this.uiRegistries = new ArrayList<>(processUiRegistries(config));
-      this.bePreReleaseRegistries = new ArrayList<>(processBePreReleaseRegistries(config));
-      this.uiPreReleaseRegistries = new ArrayList<>(processUiPreReleaseRegistries(config));
+      this.unifiedRegistries = new ArrayList<>(processCategory(
+        config.getCmdArtifactRegistries(), config.getArtifactRegistries(), UNIFIED_ALLOWED_TYPES));
+      this.beRegistries = new ArrayList<>(processCategory(
+        config.getCmdBeArtifactRegistries(), config.getBeArtifactRegistries(), BE_ALLOWED_TYPES));
+      this.uiRegistries = new ArrayList<>(processCategory(
+        config.getCmdUiArtifactRegistries(), config.getUiArtifactRegistries(), UI_ALLOWED_TYPES));
+      this.bePreReleaseRegistries = new ArrayList<>(processCategory(
+        config.getCmdBePreReleaseArtifactRegistries(), config.getBePreReleaseArtifactRegistries(), BE_ALLOWED_TYPES));
+      this.uiPreReleaseRegistries = new ArrayList<>(processCategory(
+        config.getCmdUiPreReleaseArtifactRegistries(), config.getUiPreReleaseArtifactRegistries(), UI_ALLOWED_TYPES));
 
       applyDefaults();
     }
 
-    private List<ArtifactRegistry> processUnifiedRegistries(PluginConfig config) {
-      var cmdResult = processUnifiedCmdRegistries(config.getCmdArtifactRegistries());
+    private List<ArtifactRegistry> processCategory(String cmdRegistries,
+                                                   List<ConfigArtifactRegistry> configRegistries,
+                                                   List<ArtifactRegistryType> allowedTypes) {
+      var cmdResult = processCommandLineRegistries(cmdRegistries, allowedTypes);
       invalidRegistries.addAll(cmdResult.invalidRegistries());
 
-      var configResult = processUnifiedConfigRegistries(config.getArtifactRegistries());
+      var configResult = processConfigurationRegistries(configRegistries, allowedTypes);
       invalidRegistries.addAll(configResult.invalidRegistries());
 
       return merge(cmdResult.registries(), configResult.registries());
     }
 
-    private RegistryProcessingResult processUnifiedCmdRegistries(String cmdRegistries) {
-      if (isBlank(cmdRegistries)) {
-        return new RegistryProcessingResult(emptyList(), emptyList());
-      }
-
-      var result = new ArrayList<ArtifactRegistry>();
-      var registryStrings = cmdRegistries.split(",");
-
-      for (var value : registryStrings) {
-        var dockerRegistry = artifactRegistryParser.parse(value, ArtifactRegistryType.DOCKER_HUB);
-        dockerRegistry.ifPresent(result::add);
-      }
-
-      return new RegistryProcessingResult(result, emptyList());
-    }
-
-    private RegistryProcessingResult processUnifiedConfigRegistries(List<ConfigArtifactRegistry> registries) {
-      if (registries == null || registries.isEmpty()) {
-        return new RegistryProcessingResult(emptyList(), emptyList());
-      }
-
-      var allSupportedTypes = new ArrayList<>(supportedDockerTypes);
-      allSupportedTypes.addAll(supportedNpmTypes);
-
-      return processConfigurationRegistries(registries, allSupportedTypes);
-    }
-
-    private RegistryProcessingResult processCommandLineRegistries(String registryString, ArtifactRegistryType type) {
+    private RegistryProcessingResult processCommandLineRegistries(String registryString,
+                                                                  List<ArtifactRegistryType> allowedTypes) {
       if (isBlank(registryString)) {
         return new RegistryProcessingResult(emptyList(), emptyList());
       }
 
       var result = new ArrayList<ArtifactRegistry>();
+      var invalid = new ArrayList<String>();
       var registryStrings = registryString.split(",");
 
       for (var value : registryStrings) {
-        var registry = artifactRegistryParser.parse(value, type);
-        registry.ifPresent(result::add);
+        var parsed = artifactRegistryParser.parse(value);
+        if (parsed.isEmpty()) {
+          invalid.add(value);
+          continue;
+        }
+        var registry = parsed.get();
+        if (!allowedTypes.contains(registry.getType()) || !registry.isValid()) {
+          invalid.add(value);
+        } else {
+          result.add(registry);
+        }
       }
 
-      return new RegistryProcessingResult(result, emptyList());
+      return new RegistryProcessingResult(result, invalid);
     }
 
     private RegistryProcessingResult processConfigurationRegistries(List<ConfigArtifactRegistry> registries,
-                                                                    List<String> supportedTypes) {
+                                                                    List<ArtifactRegistryType> allowedTypes) {
       if (registries == null || registries.isEmpty()) {
         return new RegistryProcessingResult(emptyList(), emptyList());
       }
 
+      var allowedValues = allowedTypes.stream().map(ArtifactRegistryType::getValue).toList();
       var invalidRegs = new ArrayList<String>();
       var result = new ArrayList<ArtifactRegistry>();
 
       for (var configRegistry : registries) {
-        if (!supportedTypes.contains(lowerCase(configRegistry.getType()))) {
+        if (!allowedValues.contains(lowerCase(configRegistry.getType()))) {
           invalidRegs.add(configRegistry.toString());
           continue;
         }
@@ -170,52 +180,6 @@ public class ArtifactRegistryProvider {
       }
 
       return new RegistryProcessingResult(result, invalidRegs);
-    }
-
-    private List<ArtifactRegistry> processBeRegistries(PluginConfig config) {
-      var cmdResult = processCommandLineRegistries(
-        config.getCmdBeArtifactRegistries(), ArtifactRegistryType.DOCKER_HUB);
-      invalidRegistries.addAll(cmdResult.invalidRegistries());
-
-      var configResult = processConfigurationRegistries(config.getBeArtifactRegistries(), supportedDockerTypes);
-      invalidRegistries.addAll(configResult.invalidRegistries());
-
-      return merge(cmdResult.registries(), configResult.registries());
-    }
-
-    private List<ArtifactRegistry> processUiRegistries(PluginConfig config) {
-      var cmdResult = processCommandLineRegistries(
-        config.getCmdUiArtifactRegistries(), ArtifactRegistryType.FOLIO_NPM);
-      invalidRegistries.addAll(cmdResult.invalidRegistries());
-
-      var configResult = processConfigurationRegistries(config.getUiArtifactRegistries(), supportedNpmTypes);
-      invalidRegistries.addAll(configResult.invalidRegistries());
-
-      return merge(cmdResult.registries(), configResult.registries());
-    }
-
-    private List<ArtifactRegistry> processBePreReleaseRegistries(PluginConfig config) {
-      var cmdResult = processCommandLineRegistries(
-        config.getCmdBePreReleaseArtifactRegistries(), ArtifactRegistryType.DOCKER_HUB);
-      invalidRegistries.addAll(cmdResult.invalidRegistries());
-
-      var configResult = processConfigurationRegistries(
-        config.getBePreReleaseArtifactRegistries(), supportedDockerTypes);
-      invalidRegistries.addAll(configResult.invalidRegistries());
-
-      return merge(cmdResult.registries(), configResult.registries());
-    }
-
-    private List<ArtifactRegistry> processUiPreReleaseRegistries(PluginConfig config) {
-      var cmdResult = processCommandLineRegistries(
-        config.getCmdUiPreReleaseArtifactRegistries(), ArtifactRegistryType.FOLIO_NPM);
-      invalidRegistries.addAll(cmdResult.invalidRegistries());
-
-      var configResult = processConfigurationRegistries(
-        config.getUiPreReleaseArtifactRegistries(), supportedNpmTypes);
-      invalidRegistries.addAll(configResult.invalidRegistries());
-
-      return merge(cmdResult.registries(), configResult.registries());
     }
 
     private void applyDefaults() {

--- a/src/main/java/org/folio/app/generator/service/ModuleRegistryProvider.java
+++ b/src/main/java/org/folio/app/generator/service/ModuleRegistryProvider.java
@@ -259,13 +259,18 @@ public class ModuleRegistryProvider {
       invalidRegistries.addAll(cmdRegistriesResultForType.invalidRegistries());
       var cmdRegistriesForType = cmdRegistriesResultForType.registries();
       if (pluginConfig.isOverrideConfigRegistries()) {
-        return merge(cmdRegistriesForType, cmdFallbackRegistries);
+        return markAsFallback(merge(cmdRegistriesForType, cmdFallbackRegistries));
       }
 
       var registriesResultForType = processConfigurationRegistries(moduleRegistries);
       invalidRegistries.addAll(registriesResultForType.invalidRegistries());
-      return merge(cmdRegistriesForType, cmdFallbackRegistries, registriesResultForType.registries(),
-        fallbackRegistries);
+      return markAsFallback(merge(cmdRegistriesForType, cmdFallbackRegistries, registriesResultForType.registries(),
+        fallbackRegistries));
+    }
+
+    private List<ModuleRegistry> markAsFallback(List<ModuleRegistry> registries) {
+      registries.forEach(r -> r.setFallback(true));
+      return registries;
     }
   }
 

--- a/src/main/java/org/folio/app/generator/service/ModuleVersionService.java
+++ b/src/main/java/org/folio/app/generator/service/ModuleVersionService.java
@@ -186,7 +186,8 @@ public class ModuleVersionService {
       .sorted(Comparator.comparing(VersionCandidate::semver).reversed())
       .toList();
 
-    if (!pluginConfig.isValidateArtifacts()) {
+    var skipForFallback = registry.isFallback() && !pluginConfig.isValidateFallbackArtifacts();
+    if (!pluginConfig.isValidateArtifacts() || skipForFallback) {
       return matchingVersions.stream().findFirst();
     }
 
@@ -215,7 +216,7 @@ public class ModuleVersionService {
     var module = new ModuleDefinition().name(moduleName).version(candidate.original());
 
     for (var registry : artifactRegistries) {
-      if (artifactExistenceCheckerFacade.get().exists(module, registry, type)) {
+      if (artifactExistenceCheckerFacade.get().exists(module, registry)) {
         log.info(String.format("Artifact found: %s-%s", moduleName, candidate.original()));
         return true;
       }

--- a/src/main/java/org/folio/app/generator/service/artifact/existence/ArtifactExistenceChecker.java
+++ b/src/main/java/org/folio/app/generator/service/artifact/existence/ArtifactExistenceChecker.java
@@ -2,11 +2,11 @@ package org.folio.app.generator.service.artifact.existence;
 
 import org.folio.app.generator.model.ModuleDefinition;
 import org.folio.app.generator.model.registry.artifact.ArtifactRegistry;
-import org.folio.app.generator.model.types.ModuleType;
+import org.folio.app.generator.model.types.ArtifactRegistryType;
 
 public interface ArtifactExistenceChecker {
 
-  ModuleType getModuleType();
+  ArtifactRegistryType getRegistryType();
 
   boolean exists(ModuleDefinition module, ArtifactRegistry registry);
 }

--- a/src/main/java/org/folio/app/generator/service/artifact/existence/ArtifactExistenceCheckerFacade.java
+++ b/src/main/java/org/folio/app/generator/service/artifact/existence/ArtifactExistenceCheckerFacade.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.folio.app.generator.conditions.ArtifactValidationCondition;
 import org.folio.app.generator.model.ModuleDefinition;
 import org.folio.app.generator.model.registry.artifact.ArtifactRegistry;
-import org.folio.app.generator.model.types.ModuleType;
+import org.folio.app.generator.model.types.ArtifactRegistryType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -17,18 +17,18 @@ import org.springframework.stereotype.Component;
 @Conditional(ArtifactValidationCondition.class)
 public class ArtifactExistenceCheckerFacade {
 
-  private final Map<ModuleType, ArtifactExistenceChecker> checkersMap;
+  private final Map<ArtifactRegistryType, ArtifactExistenceChecker> checkersMap;
 
   @Autowired
   public ArtifactExistenceCheckerFacade(List<ArtifactExistenceChecker> checkers) {
-    this.checkersMap = checkers.stream().collect(toMap(ArtifactExistenceChecker::getModuleType, identity()));
+    this.checkersMap = checkers.stream().collect(toMap(ArtifactExistenceChecker::getRegistryType, identity()));
   }
 
-  public boolean exists(ModuleDefinition module, ArtifactRegistry registry, ModuleType type) {
-    var checker = checkersMap.get(type);
+  public boolean exists(ModuleDefinition module, ArtifactRegistry registry) {
+    var checker = checkersMap.get(registry.getType());
     if (checker == null) {
       throw new IllegalStateException(
-        "No artifact existence checker found for module type: " + type
+        "No artifact existence checker found for registry type: " + registry.getType()
           + ". This indicates a configuration or programming error.");
     }
 

--- a/src/main/java/org/folio/app/generator/service/artifact/existence/DockerHubArtifactExistenceChecker.java
+++ b/src/main/java/org/folio/app/generator/service/artifact/existence/DockerHubArtifactExistenceChecker.java
@@ -10,8 +10,8 @@ import org.apache.maven.plugin.logging.Log;
 import org.folio.app.generator.conditions.DockerHubCondition;
 import org.folio.app.generator.model.ModuleDefinition;
 import org.folio.app.generator.model.registry.artifact.ArtifactRegistry;
+import org.folio.app.generator.model.types.ArtifactRegistryType;
 import org.folio.app.generator.model.types.ErrorCategory;
-import org.folio.app.generator.model.types.ModuleType;
 import org.folio.app.generator.service.exceptions.ApplicationGeneratorException;
 import org.folio.app.generator.utils.JsonConverter;
 import org.springframework.context.annotation.Conditional;
@@ -30,8 +30,8 @@ public class DockerHubArtifactExistenceChecker extends HttpArtifactExistenceChec
   }
 
   @Override
-  public ModuleType getModuleType() {
-    return ModuleType.BE;
+  public ArtifactRegistryType getRegistryType() {
+    return ArtifactRegistryType.DOCKER_HUB;
   }
 
   @Override

--- a/src/main/java/org/folio/app/generator/service/artifact/existence/EcrArtifactExistenceChecker.java
+++ b/src/main/java/org/folio/app/generator/service/artifact/existence/EcrArtifactExistenceChecker.java
@@ -1,0 +1,96 @@
+package org.folio.app.generator.service.artifact.existence;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.util.regex.Pattern;
+import org.apache.maven.plugin.logging.Log;
+import org.folio.app.generator.conditions.EcrCondition;
+import org.folio.app.generator.model.ModuleDefinition;
+import org.folio.app.generator.model.registry.artifact.ArtifactRegistry;
+import org.folio.app.generator.model.types.ArtifactRegistryType;
+import org.folio.app.generator.model.types.ErrorCategory;
+import org.folio.app.generator.service.exceptions.ApplicationGeneratorException;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ecr.EcrClient;
+import software.amazon.awssdk.services.ecr.model.DescribeImagesRequest;
+import software.amazon.awssdk.services.ecr.model.EcrException;
+import software.amazon.awssdk.services.ecr.model.ImageIdentifier;
+import software.amazon.awssdk.services.ecr.model.ImageNotFoundException;
+import software.amazon.awssdk.services.ecr.model.RepositoryNotFoundException;
+
+@Component
+@Conditional(EcrCondition.class)
+public class EcrArtifactExistenceChecker implements ArtifactExistenceChecker {
+
+  private static final Pattern ECR_REGISTRY_ID_PATTERN =
+    Pattern.compile("^https?://(\\d+)\\.dkr\\.ecr\\.[^./]+\\.amazonaws\\.com(?:\\.cn)?(?:/.*)?$");
+
+  private final EcrClient ecrClient;
+  private final Log log;
+
+  public EcrArtifactExistenceChecker(EcrClient ecrClient, Log log) {
+    this.ecrClient = ecrClient;
+    this.log = log;
+  }
+
+  @Override
+  public ArtifactRegistryType getRegistryType() {
+    return ArtifactRegistryType.AWS_ECR;
+  }
+
+  @Override
+  public boolean exists(ModuleDefinition module, ArtifactRegistry registry) {
+    var registryId = extractRegistryId(registry.getBaseUrl());
+    var repositoryName = buildRepositoryName(registry.getNamespace(), module.getName());
+    var imageTag = module.getVersion();
+
+    log.debug(String.format("Checking ECR image existence: registryId=%s, repository=%s, tag=%s",
+      registryId, repositoryName, imageTag));
+
+    var request = DescribeImagesRequest.builder()
+      .registryId(registryId)
+      .repositoryName(repositoryName)
+      .imageIds(ImageIdentifier.builder().imageTag(imageTag).build())
+      .build();
+
+    try {
+      ecrClient.describeImages(request);
+      log.debug(String.format("ECR image found: %s:%s", repositoryName, imageTag));
+      return true;
+    } catch (ImageNotFoundException e) {
+      log.warn(String.format("ECR image not found: %s:%s (registryId: %s)",
+        repositoryName, imageTag, registryId));
+      return false;
+    } catch (RepositoryNotFoundException e) {
+      log.warn(String.format("ECR repository not found: %s (registryId: %s)",
+        repositoryName, registryId));
+      return false;
+    } catch (EcrException e) {
+      throw new ApplicationGeneratorException(
+        String.format("ECR error %d for %s:%s (registryId: %s): %s",
+          e.statusCode(), repositoryName, imageTag, registryId, e.getMessage()),
+        ErrorCategory.INFRASTRUCTURE, e);
+    }
+  }
+
+  private static String extractRegistryId(String baseUrl) {
+    if (isBlank(baseUrl)) {
+      throw new ApplicationGeneratorException(
+        "ECR registry baseUrl is required (expected format: https://<accountId>.dkr.ecr.<region>.amazonaws.com)",
+        ErrorCategory.CONFIGURATION_ERROR);
+    }
+    var matcher = ECR_REGISTRY_ID_PATTERN.matcher(baseUrl);
+    if (!matcher.matches()) {
+      throw new ApplicationGeneratorException(
+        "Invalid ECR registry baseUrl: " + baseUrl
+          + " (expected format: https://<accountId>.dkr.ecr.<region>.amazonaws.com)",
+        ErrorCategory.CONFIGURATION_ERROR);
+    }
+    return matcher.group(1);
+  }
+
+  private static String buildRepositoryName(String namespace, String moduleName) {
+    return isBlank(namespace) ? moduleName : namespace + "/" + moduleName;
+  }
+}

--- a/src/main/java/org/folio/app/generator/service/artifact/existence/FolioNpmArtifactExistenceChecker.java
+++ b/src/main/java/org/folio/app/generator/service/artifact/existence/FolioNpmArtifactExistenceChecker.java
@@ -12,7 +12,7 @@ import org.apache.maven.plugin.logging.Log;
 import org.folio.app.generator.conditions.FolioNpmCondition;
 import org.folio.app.generator.model.ModuleDefinition;
 import org.folio.app.generator.model.registry.artifact.ArtifactRegistry;
-import org.folio.app.generator.model.types.ModuleType;
+import org.folio.app.generator.model.types.ArtifactRegistryType;
 import org.folio.app.generator.utils.JsonConverter;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -28,8 +28,8 @@ public class FolioNpmArtifactExistenceChecker extends HttpArtifactExistenceCheck
   }
 
   @Override
-  public ModuleType getModuleType() {
-    return ModuleType.UI;
+  public ArtifactRegistryType getRegistryType() {
+    return ArtifactRegistryType.FOLIO_NPM;
   }
 
   @Override

--- a/src/main/java/org/folio/app/generator/service/parsers/StringArtifactRegistryParser.java
+++ b/src/main/java/org/folio/app/generator/service/parsers/StringArtifactRegistryParser.java
@@ -22,20 +22,20 @@ public class StringArtifactRegistryParser {
 
   private static final String PATH_DELIMITER = "/";
 
-  private final Pattern dockerHubPattern1 = Pattern.compile("(docker-hub)::(.{1,1024})::(.{1,1024})");
-  private final Pattern dockerHubPattern2 = Pattern.compile("(docker-hub)::(.{1,1024})");
-  private final Pattern folioNpmPattern1 = Pattern.compile("(folio-npm)::(.{1,1024})::(.{1,1024})");
-  private final Pattern folioNpmPattern2 = Pattern.compile("(folio-npm)::(.{1,1024})");
-  private final Pattern ecrPattern1 = Pattern.compile("(aws-ecr)::(.{1,1024})::(.{1,1024})");
-  private final Pattern ecrPattern2 = Pattern.compile("(aws-ecr)::(.{1,1024})");
+  private static final Pattern DOCKER_HUB_PATTERN_1 = Pattern.compile("(docker-hub)::(.{1,1024})::(.{1,1024})");
+  private static final Pattern DOCKER_HUB_PATTERN_2 = Pattern.compile("(docker-hub)::(.{1,1024})");
+  private static final Pattern FOLIO_NPM_PATTERN_1 = Pattern.compile("(folio-npm)::(.{1,1024})::(.{1,1024})");
+  private static final Pattern FOLIO_NPM_PATTERN_2 = Pattern.compile("(folio-npm)::(.{1,1024})");
+  private static final Pattern ECR_PATTERN_1 = Pattern.compile("(aws-ecr)::(.{1,1024})::(.{1,1024})");
+  private static final Pattern ECR_PATTERN_2 = Pattern.compile("(aws-ecr)::(.{1,1024})");
 
-  private final List<Pair<Pattern, Function<String[], ArtifactRegistry>>> patterns = List.of(
-    Pair.of(dockerHubPattern1, StringArtifactRegistryParser::parseDockerHubString),
-    Pair.of(dockerHubPattern2, StringArtifactRegistryParser::parseDockerHubString),
-    Pair.of(folioNpmPattern1, StringArtifactRegistryParser::parseFolioNpmString),
-    Pair.of(folioNpmPattern2, StringArtifactRegistryParser::parseFolioNpmString),
-    Pair.of(ecrPattern1, StringArtifactRegistryParser::parseEcrString),
-    Pair.of(ecrPattern2, StringArtifactRegistryParser::parseEcrString));
+  private static final List<Pair<Pattern, Function<String[], ArtifactRegistry>>> PATTERNS = List.of(
+    Pair.of(DOCKER_HUB_PATTERN_1, StringArtifactRegistryParser::parseDockerHubString),
+    Pair.of(DOCKER_HUB_PATTERN_2, StringArtifactRegistryParser::parseDockerHubString),
+    Pair.of(FOLIO_NPM_PATTERN_1, StringArtifactRegistryParser::parseFolioNpmString),
+    Pair.of(FOLIO_NPM_PATTERN_2, StringArtifactRegistryParser::parseFolioNpmString),
+    Pair.of(ECR_PATTERN_1, StringArtifactRegistryParser::parseEcrString),
+    Pair.of(ECR_PATTERN_2, StringArtifactRegistryParser::parseEcrString));
 
   /**
    * Parses an artifact registry string into an {@link ArtifactRegistry}.
@@ -59,7 +59,7 @@ public class StringArtifactRegistryParser {
     }
 
     var value = registryString.trim();
-    for (var patternPair : patterns) {
+    for (var patternPair : PATTERNS) {
       var pattern = patternPair.getLeft();
       var matcher = pattern.matcher(value);
       if (matcher.matches()) {

--- a/src/main/java/org/folio/app/generator/service/parsers/StringArtifactRegistryParser.java
+++ b/src/main/java/org/folio/app/generator/service/parsers/StringArtifactRegistryParser.java
@@ -4,60 +4,114 @@ import static org.apache.commons.lang3.StringUtils.removeEnd;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.folio.app.generator.model.registry.artifact.ArtifactRegistry;
 import org.folio.app.generator.model.registry.artifact.DockerHubArtifactRegistry;
+import org.folio.app.generator.model.registry.artifact.EcrArtifactRegistry;
 import org.folio.app.generator.model.registry.artifact.FolioNpmArtifactRegistry;
-import org.folio.app.generator.model.types.ArtifactRegistryType;
 import org.springframework.stereotype.Component;
 
 @Component
 public class StringArtifactRegistryParser {
 
   private static final String PATH_DELIMITER = "/";
-  private static final String URL_NAMESPACE_DELIMITER = "::";
 
-  public Optional<ArtifactRegistry> parseDocker(String registryString) {
+  private final Pattern dockerHubPattern1 = Pattern.compile("(docker-hub)::(.{1,1024})::(.{1,1024})");
+  private final Pattern dockerHubPattern2 = Pattern.compile("(docker-hub)::(.{1,1024})");
+  private final Pattern folioNpmPattern1 = Pattern.compile("(folio-npm)::(.{1,1024})::(.{1,1024})");
+  private final Pattern folioNpmPattern2 = Pattern.compile("(folio-npm)::(.{1,1024})");
+  private final Pattern ecrPattern1 = Pattern.compile("(aws-ecr)::(.{1,1024})::(.{1,1024})");
+  private final Pattern ecrPattern2 = Pattern.compile("(aws-ecr)::(.{1,1024})");
+
+  private final List<Pair<Pattern, Function<String[], ArtifactRegistry>>> patterns = List.of(
+    Pair.of(dockerHubPattern1, StringArtifactRegistryParser::parseDockerHubString),
+    Pair.of(dockerHubPattern2, StringArtifactRegistryParser::parseDockerHubString),
+    Pair.of(folioNpmPattern1, StringArtifactRegistryParser::parseFolioNpmString),
+    Pair.of(folioNpmPattern2, StringArtifactRegistryParser::parseFolioNpmString),
+    Pair.of(ecrPattern1, StringArtifactRegistryParser::parseEcrString),
+    Pair.of(ecrPattern2, StringArtifactRegistryParser::parseEcrString));
+
+  /**
+   * Parses an artifact registry string into an {@link ArtifactRegistry}.
+   *
+   * <p>Supported formats:
+   * <ul>
+   *   <li>{@code docker-hub::<namespace>}</li>
+   *   <li>{@code docker-hub::<baseUrl>::<namespace>}</li>
+   *   <li>{@code folio-npm::<namespace>}</li>
+   *   <li>{@code folio-npm::<baseUrl>::<namespace>}</li>
+   *   <li>{@code aws-ecr::<baseUrl>}</li>
+   *   <li>{@code aws-ecr::<baseUrl>::<namespace>}</li>
+   * </ul>
+   *
+   * @param registryString the string to parse
+   * @return parsed {@link ArtifactRegistry}, empty if the string does not match any supported format
+   */
+  public Optional<ArtifactRegistry> parse(String registryString) {
     if (StringUtils.isBlank(registryString)) {
       return Optional.empty();
     }
 
     var value = registryString.trim();
-    var delimiterIndex = value.indexOf(URL_NAMESPACE_DELIMITER);
-
-    if (delimiterIndex > 0) {
-      var baseUrl = checkAndGetUrl(value.substring(0, delimiterIndex));
-      var namespace = value.substring(delimiterIndex + URL_NAMESPACE_DELIMITER.length()).trim();
-      return Optional.of(new DockerHubArtifactRegistry()
-        .baseUrl(removeEnd(baseUrl.toString(), PATH_DELIMITER))
-        .namespace(namespace));
+    for (var patternPair : patterns) {
+      var pattern = patternPair.getLeft();
+      var matcher = pattern.matcher(value);
+      if (matcher.matches()) {
+        var stringParts = convertToStringPartsArray(matcher);
+        return Optional.of(patternPair.getRight().apply(stringParts));
+      }
     }
 
-    return Optional.of(new DockerHubArtifactRegistry().namespace(value));
+    return Optional.empty();
   }
 
-  public Optional<ArtifactRegistry> parseNpm(String registryString) {
-    if (StringUtils.isBlank(registryString)) {
-      return Optional.empty();
+  private static String[] convertToStringPartsArray(Matcher matcher) {
+    var groupCount = matcher.groupCount();
+    var parts = new String[groupCount];
+    for (int i = 1; i <= groupCount; i++) {
+      parts[i - 1] = matcher.group(i);
     }
-
-    var value = registryString.trim();
-    var delimiterIndex = value.indexOf(URL_NAMESPACE_DELIMITER);
-
-    if (delimiterIndex > 0) {
-      var baseUrl = checkAndGetUrl(value.substring(0, delimiterIndex));
-      var repository = value.substring(delimiterIndex + URL_NAMESPACE_DELIMITER.length()).trim();
-      return Optional.of(new FolioNpmArtifactRegistry()
-        .baseUrl(removeEnd(baseUrl.toString(), PATH_DELIMITER))
-        .namespace(repository));
-    }
-
-    return Optional.of(new FolioNpmArtifactRegistry().namespace(value));
+    return parts;
   }
 
-  public Optional<ArtifactRegistry> parse(String registryString, ArtifactRegistryType type) {
-    return type == ArtifactRegistryType.DOCKER_HUB ? parseDocker(registryString) : parseNpm(registryString);
+  private static ArtifactRegistry parseDockerHubString(String[] parts) {
+    var registry = new DockerHubArtifactRegistry();
+    if (parts.length == 3) {
+      var baseUrl = checkAndGetUrl(parts[1]);
+      registry.baseUrl(removeEnd(baseUrl.toString(), PATH_DELIMITER));
+      registry.namespace(parts[2].trim());
+    } else {
+      registry.namespace(parts[1].trim());
+    }
+    return registry;
+  }
+
+  private static ArtifactRegistry parseFolioNpmString(String[] parts) {
+    var registry = new FolioNpmArtifactRegistry();
+    if (parts.length == 3) {
+      var baseUrl = checkAndGetUrl(parts[1]);
+      registry.baseUrl(removeEnd(baseUrl.toString(), PATH_DELIMITER));
+      registry.namespace(parts[2].trim());
+    } else {
+      registry.namespace(parts[1].trim());
+    }
+    return registry;
+  }
+
+  private static ArtifactRegistry parseEcrString(String[] parts) {
+    var registry = new EcrArtifactRegistry();
+    var baseUrl = checkAndGetUrl(parts[1]);
+    registry.baseUrl(removeEnd(baseUrl.toString(), PATH_DELIMITER));
+    if (parts.length == 3) {
+      registry.namespace(parts[2].trim());
+    }
+    return registry;
   }
 
   private static URL checkAndGetUrl(String probablyUrl) {

--- a/src/main/java/org/folio/app/generator/utils/JsonConverter.java
+++ b/src/main/java/org/folio/app/generator/utils/JsonConverter.java
@@ -42,7 +42,7 @@ public class JsonConverter {
 
   public void writeValue(File file, Object value) {
     try {
-      objectMapper.writeValue(file, value);
+      objectMapper.writerWithDefaultPrettyPrinter().writeValue(file, value);
     } catch (IOException e) {
       throw new SerializationException("Failed to write value to file: " + file.getAbsolutePath(), e);
     }

--- a/src/main/java/org/folio/app/generator/utils/PluginConfig.java
+++ b/src/main/java/org/folio/app/generator/utils/PluginConfig.java
@@ -43,6 +43,9 @@ public class PluginConfig {
 
   private final boolean validateArtifacts;
 
+  @Builder.Default
+  private final boolean validateFallbackArtifacts = true;
+
   private final List<ConfigArtifactRegistry> artifactRegistries;
   private final List<ConfigArtifactRegistry> beArtifactRegistries;
   private final List<ConfigArtifactRegistry> uiArtifactRegistries;

--- a/src/test/java/org/folio/app/generator/conditions/ArtifactValidationConditionTest.java
+++ b/src/test/java/org/folio/app/generator/conditions/ArtifactValidationConditionTest.java
@@ -1,6 +1,7 @@
 package org.folio.app.generator.conditions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.app.generator.model.types.ArtifactRegistryType.AWS_ECR;
 import static org.folio.app.generator.model.types.ArtifactRegistryType.DOCKER_HUB;
 import static org.folio.app.generator.model.types.ArtifactRegistryType.FOLIO_NPM;
 import static org.folio.app.generator.model.types.RegistryType.AWS_S3;
@@ -27,6 +28,7 @@ class ArtifactValidationConditionTest {
     var properties = context.getEnvironment().getSystemProperties();
     properties.remove(DOCKER_HUB.getPropertyName());
     properties.remove(FOLIO_NPM.getPropertyName());
+    properties.remove(AWS_ECR.getPropertyName());
     properties.remove(AWS_S3.getPropertyName());
     properties.remove(OKAPI.getPropertyName());
   }
@@ -36,6 +38,7 @@ class ArtifactValidationConditionTest {
     var properties = context.getEnvironment().getSystemProperties();
     properties.remove(DOCKER_HUB.getPropertyName());
     properties.remove(FOLIO_NPM.getPropertyName());
+    properties.remove(AWS_ECR.getPropertyName());
     properties.remove(AWS_S3.getPropertyName());
     properties.remove(OKAPI.getPropertyName());
     context.close();
@@ -63,6 +66,15 @@ class ArtifactValidationConditionTest {
   void matches_positive_whenBothDockerHubAndFolioNpmEnabled() {
     context.getEnvironment().getSystemProperties().put(DOCKER_HUB.getPropertyName(), true);
     context.getEnvironment().getSystemProperties().put(FOLIO_NPM.getPropertyName(), true);
+    context.register(TestConfiguration.class);
+    context.refresh();
+
+    assertThat(context.containsBean("testBean")).isTrue();
+  }
+
+  @Test
+  void matches_positive_whenEcrEnabled() {
+    context.getEnvironment().getSystemProperties().put(AWS_ECR.getPropertyName(), true);
     context.register(TestConfiguration.class);
     context.refresh();
 
@@ -101,6 +113,7 @@ class ArtifactValidationConditionTest {
   void nestedClasses_positive_notNull() {
     assertThat(new ArtifactValidationCondition.DockerHub()).isNotNull();
     assertThat(new ArtifactValidationCondition.FolioNpm()).isNotNull();
+    assertThat(new ArtifactValidationCondition.Ecr()).isNotNull();
   }
 
   @Configuration

--- a/src/test/java/org/folio/app/generator/conditions/EcrConditionTest.java
+++ b/src/test/java/org/folio/app/generator/conditions/EcrConditionTest.java
@@ -1,0 +1,68 @@
+package org.folio.app.generator.conditions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.app.generator.support.UnitTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@UnitTest
+class EcrConditionTest {
+
+  private static final String ECR_PROPERTY = "folio-app-generator.aws-ecr.enabled";
+
+  private AnnotationConfigApplicationContext context;
+
+  @BeforeEach
+  void setUp() {
+    System.getProperties().remove(ECR_PROPERTY);
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.getProperties().remove(ECR_PROPERTY);
+    if (context != null) {
+      context.close();
+    }
+  }
+
+  @Test
+  void matches_positive_whenEcrEnabled() {
+    context = new AnnotationConfigApplicationContext();
+    context.getEnvironment().getSystemProperties()
+      .put("folio-app-generator.aws-ecr.enabled", true);
+    context.register(TestComponent.class);
+    context.refresh();
+
+    assertThat(context.containsBean("testComponent")).isTrue();
+  }
+
+  @Test
+  void matches_negative_whenEcrDisabled() {
+    context = new AnnotationConfigApplicationContext();
+    context.register(TestComponent.class);
+    context.refresh();
+
+    assertThat(context.containsBean("testComponent")).isFalse();
+  }
+
+  @Test
+  void matches_negative_whenEcrExplicitlyDisabled() {
+    context = new AnnotationConfigApplicationContext();
+    context.getEnvironment().getSystemProperties()
+      .put("folio-app-generator.aws-ecr.enabled", false);
+    context.register(TestComponent.class);
+    context.refresh();
+
+    assertThat(context.containsBean("testComponent")).isFalse();
+  }
+
+  @Component("testComponent")
+  @Conditional(EcrCondition.class)
+  static class TestComponent {
+  }
+}

--- a/src/test/java/org/folio/app/generator/configuration/SpringConfigurationTest.java
+++ b/src/test/java/org/folio/app/generator/configuration/SpringConfigurationTest.java
@@ -1,0 +1,60 @@
+package org.folio.app.generator.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import org.folio.app.generator.support.UnitTest;
+import org.folio.app.generator.utils.PluginConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ecr.EcrClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@UnitTest
+class SpringConfigurationTest {
+
+  private SpringConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new SpringConfiguration();
+  }
+
+  @Test
+  void httpClient_positive_isCreated() {
+    var httpClient = configuration.httpClient();
+
+    assertThat(httpClient).isNotNull();
+  }
+
+  @Test
+  void amazonS3Client_positive_withoutEndpointOverride() {
+    var config = PluginConfig.builder().awsRegion(Region.US_EAST_1).build();
+
+    try (S3Client client = configuration.amazonS3Client(config)) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  @Test
+  void amazonS3Client_positive_withEndpointOverride() {
+    var config = PluginConfig.builder()
+      .awsRegion(Region.US_EAST_1)
+      .awsEndpointOverride(URI.create("http://localhost:4566"))
+      .build();
+
+    try (S3Client client = configuration.amazonS3Client(config)) {
+      assertThat(client).isNotNull();
+    }
+  }
+
+  @Test
+  void ecrClient_positive_isCreated() {
+    var config = PluginConfig.builder().awsRegion(Region.US_WEST_2).build();
+
+    try (EcrClient client = configuration.ecrClient(config)) {
+      assertThat(client).isNotNull();
+    }
+  }
+}

--- a/src/test/java/org/folio/app/generator/model/registry/artifact/EcrArtifactRegistryTest.java
+++ b/src/test/java/org/folio/app/generator/model/registry/artifact/EcrArtifactRegistryTest.java
@@ -1,0 +1,62 @@
+package org.folio.app.generator.model.registry.artifact;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.app.generator.model.types.ArtifactRegistryType;
+import org.folio.app.generator.support.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class EcrArtifactRegistryTest {
+
+  private static final String VALID_ECR_URL = "https://123456789012.dkr.ecr.us-west-2.amazonaws.com";
+
+  @Test
+  void isValid_positive_withNamespace() {
+    var registry = new EcrArtifactRegistry().baseUrl(VALID_ECR_URL).namespace("folio");
+
+    assertThat(registry.isValid()).isTrue();
+  }
+
+  @Test
+  void isValid_positive_withoutNamespace() {
+    var registry = new EcrArtifactRegistry().baseUrl(VALID_ECR_URL);
+
+    assertThat(registry.isValid()).isTrue();
+  }
+
+  @Test
+  void isValid_negative_nullBaseUrl() {
+    var registry = new EcrArtifactRegistry();
+
+    assertThat(registry.isValid()).isFalse();
+  }
+
+  @Test
+  void isValid_negative_blankBaseUrl() {
+    var registry = new EcrArtifactRegistry().baseUrl("");
+
+    assertThat(registry.isValid()).isFalse();
+  }
+
+  @Test
+  void isValid_negative_malformedBaseUrl() {
+    var registry = new EcrArtifactRegistry().baseUrl("not-a-valid-url");
+
+    assertThat(registry.isValid()).isFalse();
+  }
+
+  @Test
+  void getType_positive() {
+    var registry = new EcrArtifactRegistry();
+
+    assertThat(registry.getType()).isEqualTo(ArtifactRegistryType.AWS_ECR);
+  }
+
+  @Test
+  void defaultBaseUrl_positive_isNull() {
+    var registry = new EcrArtifactRegistry();
+
+    assertThat(registry.getBaseUrl()).isNull();
+  }
+}

--- a/src/test/java/org/folio/app/generator/service/ArtifactRegistryProviderTest.java
+++ b/src/test/java/org/folio/app/generator/service/ArtifactRegistryProviderTest.java
@@ -96,6 +96,53 @@ class ArtifactRegistryProviderTest {
   }
 
   @Test
+  void getArtifactRegistries_positive_ecrFromConfigWithoutNamespace() {
+    var ecrRegistry = new ConfigArtifactRegistry();
+    ecrRegistry.setType("aws-ecr");
+    ecrRegistry.setBaseUrl("https://123456789012.dkr.ecr.us-west-2.amazonaws.com");
+    // namespace not set — ECR allows it (isValid requires only baseUrl)
+    var config = PluginConfig.builder()
+      .beArtifactRegistries(List.of(ecrRegistry))
+      .build();
+
+    var result = artifactRegistryProvider.getArtifactRegistries(config);
+
+    assertThat(result.beRegistries()).hasSize(1);
+    assertThat(result.beRegistries().get(0)).isInstanceOf(EcrArtifactRegistry.class);
+    assertThat(result.beRegistries().get(0).getBaseUrl())
+      .isEqualTo("https://123456789012.dkr.ecr.us-west-2.amazonaws.com");
+    assertThat(result.beRegistries().get(0).getNamespace()).isNull();
+  }
+
+  @Test
+  void getArtifactRegistries_negative_ecrFromConfigWithoutBaseUrl() {
+    var ecrRegistry = new ConfigArtifactRegistry();
+    ecrRegistry.setType("aws-ecr");
+    // baseUrl not set — ECR requires baseUrl, isValid returns false
+    ecrRegistry.setNamespace("folio");
+    var config = PluginConfig.builder()
+      .beArtifactRegistries(List.of(ecrRegistry))
+      .build();
+
+    assertThatThrownBy(() -> artifactRegistryProvider.getArtifactRegistries(config))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Invalid artifact registries found");
+  }
+
+  @Test
+  void getArtifactRegistries_negative_cliEntryParsesButIsInvalid() {
+    // parses successfully (matches docker-hub::(.{1,1024})), but namespace trims to blank
+    // so DockerHubArtifactRegistry.isValid() returns false, entry rejected
+    var config = PluginConfig.builder()
+      .cmdBeArtifactRegistries("docker-hub::   ")
+      .build();
+
+    assertThatThrownBy(() -> artifactRegistryProvider.getArtifactRegistries(config))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Invalid artifact registries found");
+  }
+
+  @Test
   void getArtifactRegistries_negative_ecrUnderUiCategory() {
     var ecrRegistry = new ConfigArtifactRegistry();
     ecrRegistry.setType("aws-ecr");

--- a/src/test/java/org/folio/app/generator/service/ArtifactRegistryProviderTest.java
+++ b/src/test/java/org/folio/app/generator/service/ArtifactRegistryProviderTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import org.folio.app.generator.model.registry.artifact.ConfigArtifactRegistry;
+import org.folio.app.generator.model.registry.artifact.EcrArtifactRegistry;
 import org.folio.app.generator.model.types.ModuleType;
 import org.folio.app.generator.service.parsers.StringArtifactRegistryParser;
 import org.folio.app.generator.support.UnitTest;
@@ -76,9 +77,43 @@ class ArtifactRegistryProviderTest {
   }
 
   @Test
+  void getArtifactRegistries_positive_ecrBeRegistryFromConfig() {
+    var ecrRegistry = new ConfigArtifactRegistry();
+    ecrRegistry.setType("aws-ecr");
+    ecrRegistry.setBaseUrl("https://123456789012.dkr.ecr.us-west-2.amazonaws.com");
+    ecrRegistry.setNamespace("folio");
+    var config = PluginConfig.builder()
+      .beArtifactRegistries(List.of(ecrRegistry))
+      .build();
+
+    var result = artifactRegistryProvider.getArtifactRegistries(config);
+
+    assertThat(result.beRegistries()).hasSize(1);
+    assertThat(result.beRegistries().get(0)).isInstanceOf(EcrArtifactRegistry.class);
+    assertThat(result.beRegistries().get(0).getBaseUrl())
+      .isEqualTo("https://123456789012.dkr.ecr.us-west-2.amazonaws.com");
+    assertThat(result.beRegistries().get(0).getNamespace()).isEqualTo("folio");
+  }
+
+  @Test
+  void getArtifactRegistries_negative_ecrUnderUiCategory() {
+    var ecrRegistry = new ConfigArtifactRegistry();
+    ecrRegistry.setType("aws-ecr");
+    ecrRegistry.setBaseUrl("https://123456789012.dkr.ecr.us-west-2.amazonaws.com");
+    ecrRegistry.setNamespace("folio");
+    var config = PluginConfig.builder()
+      .uiArtifactRegistries(List.of(ecrRegistry))
+      .build();
+
+    assertThatThrownBy(() -> artifactRegistryProvider.getArtifactRegistries(config))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Invalid artifact registries found");
+  }
+
+  @Test
   void getArtifactRegistries_positive_customBeRegistryFromCommandLine() {
     var config = PluginConfig.builder()
-      .cmdBeArtifactRegistries("my-namespace")
+      .cmdBeArtifactRegistries("docker-hub::my-namespace")
       .build();
 
     var result = artifactRegistryProvider.getArtifactRegistries(config);
@@ -91,7 +126,7 @@ class ArtifactRegistryProviderTest {
   @Test
   void getArtifactRegistries_positive_customUiRegistryFromCommandLine() {
     var config = PluginConfig.builder()
-      .cmdUiArtifactRegistries("my-npm-repo")
+      .cmdUiArtifactRegistries("folio-npm::my-npm-repo")
       .build();
 
     var result = artifactRegistryProvider.getArtifactRegistries(config);
@@ -102,9 +137,24 @@ class ArtifactRegistryProviderTest {
   }
 
   @Test
+  void getArtifactRegistries_positive_ecrFromCommandLine() {
+    var config = PluginConfig.builder()
+      .cmdBeArtifactRegistries("aws-ecr::https://123456789012.dkr.ecr.us-west-2.amazonaws.com::folio")
+      .build();
+
+    var result = artifactRegistryProvider.getArtifactRegistries(config);
+
+    assertThat(result.beRegistries()).hasSize(1);
+    assertThat(result.beRegistries().get(0)).isInstanceOf(EcrArtifactRegistry.class);
+    assertThat(result.beRegistries().get(0).getBaseUrl())
+      .isEqualTo("https://123456789012.dkr.ecr.us-west-2.amazonaws.com");
+    assertThat(result.beRegistries().get(0).getNamespace()).isEqualTo("folio");
+  }
+
+  @Test
   void getArtifactRegistries_positive_customRegistryWithUrl() {
     var config = PluginConfig.builder()
-      .cmdBeArtifactRegistries("https://custom-registry.io::custom-ns")
+      .cmdBeArtifactRegistries("docker-hub::https://custom-registry.io::custom-ns")
       .build();
 
     var result = artifactRegistryProvider.getArtifactRegistries(config);
@@ -117,7 +167,7 @@ class ArtifactRegistryProviderTest {
   @Test
   void getArtifactRegistries_positive_multipleCommandLineRegistries() {
     var config = PluginConfig.builder()
-      .cmdBeArtifactRegistries("namespace1,namespace2,namespace3")
+      .cmdBeArtifactRegistries("docker-hub::namespace1,docker-hub::namespace2,docker-hub::namespace3")
       .build();
 
     var result = artifactRegistryProvider.getArtifactRegistries(config);
@@ -129,12 +179,26 @@ class ArtifactRegistryProviderTest {
   }
 
   @Test
+  void getArtifactRegistries_positive_mixedDockerHubAndEcrCommandLine() {
+    var config = PluginConfig.builder()
+      .cmdBeArtifactRegistries(
+        "docker-hub::folioorg,aws-ecr::https://123456789012.dkr.ecr.us-west-2.amazonaws.com::folio")
+      .build();
+
+    var result = artifactRegistryProvider.getArtifactRegistries(config);
+
+    assertThat(result.beRegistries()).hasSize(2);
+    assertThat(result.beRegistries().get(0).getNamespace()).isEqualTo("folioorg");
+    assertThat(result.beRegistries().get(1)).isInstanceOf(EcrArtifactRegistry.class);
+  }
+
+  @Test
   void getArtifactRegistries_positive_combineCommandLineAndConfigRegistries() {
     var beRegistry = new ConfigArtifactRegistry();
     beRegistry.setType("docker-hub");
     beRegistry.setNamespace("config-namespace");
     var config = PluginConfig.builder()
-      .cmdBeArtifactRegistries("cmd-namespace")
+      .cmdBeArtifactRegistries("docker-hub::cmd-namespace")
       .beArtifactRegistries(List.of(beRegistry))
       .build();
 
@@ -152,6 +216,28 @@ class ArtifactRegistryProviderTest {
     invalidRegistry.setNamespace("test");
     var config = PluginConfig.builder()
       .beArtifactRegistries(List.of(invalidRegistry))
+      .build();
+
+    assertThatThrownBy(() -> artifactRegistryProvider.getArtifactRegistries(config))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Invalid artifact registries found");
+  }
+
+  @Test
+  void getArtifactRegistries_negative_bareNamespaceCommandLineRejected() {
+    var config = PluginConfig.builder()
+      .cmdBeArtifactRegistries("folioorg")
+      .build();
+
+    assertThatThrownBy(() -> artifactRegistryProvider.getArtifactRegistries(config))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Invalid artifact registries found");
+  }
+
+  @Test
+  void getArtifactRegistries_negative_folioNpmInBeCommandLine() {
+    var config = PluginConfig.builder()
+      .cmdBeArtifactRegistries("folio-npm::npm-folio")
       .build();
 
     assertThatThrownBy(() -> artifactRegistryProvider.getArtifactRegistries(config))
@@ -243,7 +329,7 @@ class ArtifactRegistryProviderTest {
   @Test
   void getArtifactRegistries_positive_preReleaseRegistriesFromCommandLine() {
     var config = PluginConfig.builder()
-      .cmdBePreReleaseArtifactRegistries("snapshot-ns")
+      .cmdBePreReleaseArtifactRegistries("docker-hub::snapshot-ns")
       .build();
 
     var result = artifactRegistryProvider.getArtifactRegistries(config);
@@ -373,7 +459,7 @@ class ArtifactRegistryProviderTest {
   @Test
   void getArtifactRegistries_positive_unifiedRegistriesFromCommandLine() {
     var config = PluginConfig.builder()
-      .cmdArtifactRegistries("docker-ns,npm-ns")
+      .cmdArtifactRegistries("docker-hub::docker-ns,folio-npm::npm-ns")
       .build();
 
     var result = artifactRegistryProvider.getArtifactRegistries(config);

--- a/src/test/java/org/folio/app/generator/service/ArtifactRegistryProviderTest.java
+++ b/src/test/java/org/folio/app/generator/service/ArtifactRegistryProviderTest.java
@@ -130,19 +130,6 @@ class ArtifactRegistryProviderTest {
   }
 
   @Test
-  void getArtifactRegistries_negative_cliEntryParsesButIsInvalid() {
-    // parses successfully (matches docker-hub::(.{1,1024})), but namespace trims to blank
-    // so DockerHubArtifactRegistry.isValid() returns false, entry rejected
-    var config = PluginConfig.builder()
-      .cmdBeArtifactRegistries("docker-hub::   ")
-      .build();
-
-    assertThatThrownBy(() -> artifactRegistryProvider.getArtifactRegistries(config))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessageContaining("Invalid artifact registries found");
-  }
-
-  @Test
   void getArtifactRegistries_negative_ecrUnderUiCategory() {
     var ecrRegistry = new ConfigArtifactRegistry();
     ecrRegistry.setType("aws-ecr");

--- a/src/test/java/org/folio/app/generator/service/ModuleVersionServiceTest.java
+++ b/src/test/java/org/folio/app/generator/service/ModuleVersionServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -374,7 +375,7 @@ class ModuleVersionServiceTest {
     when(resolverFacade.getAvailableVersions(registry, dependency, ModuleType.BE))
         .thenReturn(Optional.of(List.of("1.5.0", "1.4.0", "1.3.0", "1.0.0")));
     when(artifactRegistryProvider.getArtifactRegistries(pluginConfig)).thenReturn(artifactRegistries);
-    when(artifactExistenceCheckerFacade.exists(any(), any(), eq(ModuleType.BE)))
+    when(artifactExistenceCheckerFacade.exists(any(), any()))
         .thenReturn(false)
         .thenReturn(false)
         .thenReturn(true);
@@ -399,7 +400,7 @@ class ModuleVersionServiceTest {
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getVersion()).isEqualTo("1.5.0");
-    verify(artifactExistenceCheckerFacade, never()).exists(any(), any(), any());
+    verify(artifactExistenceCheckerFacade, never()).exists(any(), any());
   }
 
   @Test
@@ -413,7 +414,7 @@ class ModuleVersionServiceTest {
     when(resolverFacade.getAvailableVersions(registry, dependency, ModuleType.BE))
         .thenReturn(Optional.of(List.of("1.5.0", "1.4.0")));
     when(artifactRegistryProvider.getArtifactRegistries(pluginConfig)).thenReturn(artifactRegistries);
-    when(artifactExistenceCheckerFacade.exists(any(), any(), eq(ModuleType.BE))).thenReturn(false);
+    when(artifactExistenceCheckerFacade.exists(any(), any())).thenReturn(false);
 
     var dependencies = List.of(dependency);
     assertThatThrownBy(() -> service.resolveModulesConstraints(dependencies, ModuleType.BE))
@@ -432,7 +433,7 @@ class ModuleVersionServiceTest {
     when(resolverFacade.getAvailableVersions(registry, dependency, ModuleType.BE))
         .thenReturn(Optional.of(List.of("1.5.0-SNAPSHOT.123")));
     when(artifactRegistryProvider.getArtifactRegistries(pluginConfig)).thenReturn(artifactRegistries);
-    when(artifactExistenceCheckerFacade.exists(any(), any(), eq(ModuleType.BE))).thenReturn(true);
+    when(artifactExistenceCheckerFacade.exists(any(), any())).thenReturn(true);
 
     var result = service.resolveModulesConstraints(List.of(dependency), ModuleType.BE);
 
@@ -451,7 +452,7 @@ class ModuleVersionServiceTest {
     when(resolverFacade.getAvailableVersions(registry, dependency, ModuleType.UI))
         .thenReturn(Optional.of(List.of("1.5.0", "1.4.0")));
     when(artifactRegistryProvider.getArtifactRegistries(pluginConfig)).thenReturn(artifactRegistries);
-    when(artifactExistenceCheckerFacade.exists(any(), any(), eq(ModuleType.UI)))
+    when(artifactExistenceCheckerFacade.exists(any(), any()))
         .thenReturn(false)
         .thenReturn(true);
 
@@ -703,12 +704,88 @@ class ModuleVersionServiceTest {
     verify(log).warn("Module registries are empty for type: BE");
   }
 
+  @Test
+  void resolveModulesConstraints_positive_validateFallbackArtifactsFalse_fallbackSkipped() {
+    var dependency = new Dependency("mod-foo", "^1.0.0", PreReleaseFilter.FALSE);
+    var mainRegistry = okapiRegistry();
+    var fallbackRegistry = fallbackS3Registry();
+
+    when(pluginConfig.isValidateArtifacts()).thenReturn(true);
+    when(pluginConfig.isValidateFallbackArtifacts()).thenReturn(false);
+    when(moduleRegistries.getRegistries(ModuleType.BE)).thenReturn(List.of(mainRegistry));
+    when(moduleRegistries.getFallbackRegistries(ModuleType.BE)).thenReturn(List.of(fallbackRegistry));
+    when(resolverFacade.getAvailableVersions(mainRegistry, dependency, ModuleType.BE))
+        .thenReturn(Optional.empty());
+    when(resolverFacade.getAvailableVersions(fallbackRegistry, dependency, ModuleType.BE))
+        .thenReturn(Optional.of(List.of("1.5.0", "1.2.0")));
+
+    var result = service.resolveModulesConstraints(List.of(dependency), ModuleType.BE);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getVersion()).isEqualTo("1.5.0");
+    verify(artifactExistenceCheckerFacade, never()).exists(any(), any());
+  }
+
+  @Test
+  void resolveModulesConstraints_positive_validateFallbackArtifactsFalse_primaryStillValidated() {
+    var dependency = new Dependency("mod-foo", "^1.0.0", PreReleaseFilter.FALSE);
+    var mainRegistry = okapiRegistry();
+    var artifactRegistries = createDefaultArtifactRegistries();
+
+    when(pluginConfig.isValidateArtifacts()).thenReturn(true);
+    when(moduleRegistries.getRegistries(ModuleType.BE)).thenReturn(List.of(mainRegistry));
+    when(resolverFacade.getAvailableVersions(mainRegistry, dependency, ModuleType.BE))
+        .thenReturn(Optional.of(List.of("1.5.0", "1.2.0")));
+    when(artifactRegistryProvider.getArtifactRegistries(pluginConfig)).thenReturn(artifactRegistries);
+    when(artifactExistenceCheckerFacade.exists(any(), any()))
+        .thenReturn(false)
+        .thenReturn(true);
+
+    var result = service.resolveModulesConstraints(List.of(dependency), ModuleType.BE);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getVersion()).isEqualTo("1.2.0");
+    verify(artifactExistenceCheckerFacade, times(2)).exists(any(), any());
+  }
+
+  @Test
+  void resolveModulesConstraints_positive_validateFallbackArtifactsTrue_fallbackStillValidated() {
+    var dependency = new Dependency("mod-foo", "^1.0.0", PreReleaseFilter.FALSE);
+    var mainRegistry = okapiRegistry();
+    var fallbackRegistry = fallbackS3Registry();
+    var artifactRegistries = createDefaultArtifactRegistries();
+
+    when(pluginConfig.isValidateArtifacts()).thenReturn(true);
+    when(pluginConfig.isValidateFallbackArtifacts()).thenReturn(true);
+    when(moduleRegistries.getRegistries(ModuleType.BE)).thenReturn(List.of(mainRegistry));
+    when(moduleRegistries.getFallbackRegistries(ModuleType.BE)).thenReturn(List.of(fallbackRegistry));
+    when(resolverFacade.getAvailableVersions(mainRegistry, dependency, ModuleType.BE))
+        .thenReturn(Optional.empty());
+    when(resolverFacade.getAvailableVersions(fallbackRegistry, dependency, ModuleType.BE))
+        .thenReturn(Optional.of(List.of("1.5.0", "1.2.0")));
+    when(artifactRegistryProvider.getArtifactRegistries(pluginConfig)).thenReturn(artifactRegistries);
+    when(artifactExistenceCheckerFacade.exists(any(), any())).thenReturn(true);
+
+    var result = service.resolveModulesConstraints(List.of(dependency), ModuleType.BE);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getVersion()).isEqualTo("1.5.0");
+    verify(artifactExistenceCheckerFacade).exists(any(), any());
+  }
+
   private static OkapiModuleRegistry okapiRegistry() {
     return new OkapiModuleRegistry().url("http://localhost").withGeneratedFields();
   }
 
   private static S3ModuleRegistry s3Registry() {
     return new S3ModuleRegistry().bucket("test-bucket").path("modules/").withGeneratedFields();
+  }
+
+  private static S3ModuleRegistry fallbackS3Registry() {
+    var registry = (S3ModuleRegistry) new S3ModuleRegistry()
+        .bucket("test-bucket").path("modules/").withGeneratedFields();
+    registry.setFallback(true);
+    return registry;
   }
 
   private static ArtifactRegistries createDefaultArtifactRegistries() {

--- a/src/test/java/org/folio/app/generator/service/artifact/existence/ArtifactExistenceCheckerFacadeTest.java
+++ b/src/test/java/org/folio/app/generator/service/artifact/existence/ArtifactExistenceCheckerFacadeTest.java
@@ -8,8 +8,9 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import org.folio.app.generator.model.ModuleDefinition;
 import org.folio.app.generator.model.registry.artifact.DockerHubArtifactRegistry;
+import org.folio.app.generator.model.registry.artifact.EcrArtifactRegistry;
 import org.folio.app.generator.model.registry.artifact.FolioNpmArtifactRegistry;
-import org.folio.app.generator.model.types.ModuleType;
+import org.folio.app.generator.model.types.ArtifactRegistryType;
 import org.folio.app.generator.support.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,42 +22,59 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ArtifactExistenceCheckerFacadeTest {
 
-  @Mock private ArtifactExistenceChecker beChecker;
-  @Mock private ArtifactExistenceChecker uiChecker;
+  @Mock private ArtifactExistenceChecker dockerHubChecker;
+  @Mock private ArtifactExistenceChecker folioNpmChecker;
+  @Mock private ArtifactExistenceChecker ecrChecker;
 
   private ArtifactExistenceCheckerFacade facade;
 
   @BeforeEach
   void setUp() {
-    when(beChecker.getModuleType()).thenReturn(ModuleType.BE);
-    when(uiChecker.getModuleType()).thenReturn(ModuleType.UI);
-    facade = new ArtifactExistenceCheckerFacade(List.of(beChecker, uiChecker));
+    when(dockerHubChecker.getRegistryType()).thenReturn(ArtifactRegistryType.DOCKER_HUB);
+    when(folioNpmChecker.getRegistryType()).thenReturn(ArtifactRegistryType.FOLIO_NPM);
+    when(ecrChecker.getRegistryType()).thenReturn(ArtifactRegistryType.AWS_ECR);
+    facade = new ArtifactExistenceCheckerFacade(List.of(dockerHubChecker, folioNpmChecker, ecrChecker));
   }
 
   @Test
-  void exists_positive_beModule() {
+  void exists_positive_dockerHub() {
     var module = new ModuleDefinition().name("mod-users").version("1.0.0");
     var registry = new DockerHubArtifactRegistry().namespace("folioorg");
 
-    when(beChecker.exists(module, registry)).thenReturn(true);
+    when(dockerHubChecker.exists(module, registry)).thenReturn(true);
 
-    var result = facade.exists(module, registry, ModuleType.BE);
+    var result = facade.exists(module, registry);
 
     assertThat(result).isTrue();
-    verify(beChecker).exists(module, registry);
+    verify(dockerHubChecker).exists(module, registry);
   }
 
   @Test
-  void exists_positive_uiModule() {
+  void exists_positive_folioNpm() {
     var module = new ModuleDefinition().name("folio_users").version("1.0.0");
     var registry = new FolioNpmArtifactRegistry().namespace("npm-folio");
 
-    when(uiChecker.exists(module, registry)).thenReturn(true);
+    when(folioNpmChecker.exists(module, registry)).thenReturn(true);
 
-    var result = facade.exists(module, registry, ModuleType.UI);
+    var result = facade.exists(module, registry);
 
     assertThat(result).isTrue();
-    verify(uiChecker).exists(module, registry);
+    verify(folioNpmChecker).exists(module, registry);
+  }
+
+  @Test
+  void exists_positive_ecr() {
+    var module = new ModuleDefinition().name("mod-users").version("1.2.0-SNAPSHOT.5dc446");
+    var registry = new EcrArtifactRegistry()
+      .baseUrl("https://123456789012.dkr.ecr.us-west-2.amazonaws.com")
+      .namespace("folio");
+
+    when(ecrChecker.exists(module, registry)).thenReturn(true);
+
+    var result = facade.exists(module, registry);
+
+    assertThat(result).isTrue();
+    verify(ecrChecker).exists(module, registry);
   }
 
   @Test
@@ -64,23 +82,23 @@ class ArtifactExistenceCheckerFacadeTest {
     var module = new ModuleDefinition().name("mod-users").version("1.0.0");
     var registry = new DockerHubArtifactRegistry().namespace("folioorg");
 
-    when(beChecker.exists(module, registry)).thenReturn(false);
+    when(dockerHubChecker.exists(module, registry)).thenReturn(false);
 
-    var result = facade.exists(module, registry, ModuleType.BE);
+    var result = facade.exists(module, registry);
 
     assertThat(result).isFalse();
   }
 
   @Test
-  void exists_negative_unknownModuleType() {
-    var module = new ModuleDefinition().name("mod-users").version("1.0.0");
-    var registry = new DockerHubArtifactRegistry().namespace("folioorg");
+  void exists_negative_unknownRegistryType() {
+    var module = new ModuleDefinition().name("folio_users").version("1.0.0");
+    var registry = new FolioNpmArtifactRegistry().namespace("npm-folio");
 
-    var facadeWithLimitedCheckers = new ArtifactExistenceCheckerFacade(List.of(beChecker));
+    var facadeWithLimitedCheckers = new ArtifactExistenceCheckerFacade(List.of(dockerHubChecker));
 
-    assertThatThrownBy(() -> facadeWithLimitedCheckers.exists(module, registry, ModuleType.UI))
+    assertThatThrownBy(() -> facadeWithLimitedCheckers.exists(module, registry))
       .isInstanceOf(IllegalStateException.class)
-      .hasMessageContaining("No artifact existence checker found for module type: UI")
+      .hasMessageContaining("No artifact existence checker found for registry type: FOLIO_NPM")
       .hasMessageContaining("configuration or programming error");
   }
 }

--- a/src/test/java/org/folio/app/generator/service/artifact/existence/DockerHubArtifactExistenceCheckerTest.java
+++ b/src/test/java/org/folio/app/generator/service/artifact/existence/DockerHubArtifactExistenceCheckerTest.java
@@ -17,8 +17,8 @@ import java.net.http.HttpResponse;
 import org.apache.maven.plugin.logging.Log;
 import org.folio.app.generator.model.ModuleDefinition;
 import org.folio.app.generator.model.registry.artifact.DockerHubArtifactRegistry;
+import org.folio.app.generator.model.types.ArtifactRegistryType;
 import org.folio.app.generator.model.types.ErrorCategory;
-import org.folio.app.generator.model.types.ModuleType;
 import org.folio.app.generator.service.exceptions.ApplicationGeneratorException;
 import org.folio.app.generator.support.UnitTest;
 import org.folio.app.generator.utils.JsonConverter;
@@ -45,8 +45,8 @@ class DockerHubArtifactExistenceCheckerTest {
   }
 
   @Test
-  void getModuleType_positive() {
-    assertThat(checker.getModuleType()).isEqualTo(ModuleType.BE);
+  void getRegistryType_positive() {
+    assertThat(checker.getRegistryType()).isEqualTo(ArtifactRegistryType.DOCKER_HUB);
   }
 
   @Test

--- a/src/test/java/org/folio/app/generator/service/artifact/existence/EcrArtifactExistenceCheckerTest.java
+++ b/src/test/java/org/folio/app/generator/service/artifact/existence/EcrArtifactExistenceCheckerTest.java
@@ -1,0 +1,141 @@
+package org.folio.app.generator.service.artifact.existence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.maven.plugin.logging.Log;
+import org.folio.app.generator.model.ModuleDefinition;
+import org.folio.app.generator.model.registry.artifact.EcrArtifactRegistry;
+import org.folio.app.generator.model.types.ArtifactRegistryType;
+import org.folio.app.generator.model.types.ErrorCategory;
+import org.folio.app.generator.service.exceptions.ApplicationGeneratorException;
+import org.folio.app.generator.support.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.ecr.EcrClient;
+import software.amazon.awssdk.services.ecr.model.DescribeImagesRequest;
+import software.amazon.awssdk.services.ecr.model.DescribeImagesResponse;
+import software.amazon.awssdk.services.ecr.model.EcrException;
+import software.amazon.awssdk.services.ecr.model.ImageNotFoundException;
+import software.amazon.awssdk.services.ecr.model.RepositoryNotFoundException;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class EcrArtifactExistenceCheckerTest {
+
+  private static final String ECR_BASE_URL = "https://123456789012.dkr.ecr.us-west-2.amazonaws.com";
+  private static final String REGISTRY_ID = "123456789012";
+
+  @Mock private EcrClient ecrClient;
+  @Mock private Log log;
+
+  private EcrArtifactExistenceChecker checker;
+
+  @BeforeEach
+  void setUp() {
+    checker = new EcrArtifactExistenceChecker(ecrClient, log);
+  }
+
+  @Test
+  void getRegistryType_positive() {
+    assertThat(checker.getRegistryType()).isEqualTo(ArtifactRegistryType.AWS_ECR);
+  }
+
+  @Test
+  void exists_positive_imageFound() {
+    var module = new ModuleDefinition().name("mod-users").version("1.2.0-SNAPSHOT.5dc446");
+    var registry = new EcrArtifactRegistry().baseUrl(ECR_BASE_URL).namespace("folio");
+
+    when(ecrClient.describeImages(any(DescribeImagesRequest.class)))
+      .thenReturn(DescribeImagesResponse.builder().build());
+
+    assertThat(checker.exists(module, registry)).isTrue();
+    verify(log).debug("ECR image found: folio/mod-users:1.2.0-SNAPSHOT.5dc446");
+  }
+
+  @Test
+  void exists_positive_noNamespace() {
+    var module = new ModuleDefinition().name("mod-users").version("1.0.0");
+    var registry = new EcrArtifactRegistry().baseUrl(ECR_BASE_URL);
+
+    when(ecrClient.describeImages(any(DescribeImagesRequest.class)))
+      .thenReturn(DescribeImagesResponse.builder().build());
+
+    assertThat(checker.exists(module, registry)).isTrue();
+    verify(log).debug("ECR image found: mod-users:1.0.0");
+  }
+
+  @Test
+  void exists_negative_imageNotFound() {
+    var module = new ModuleDefinition().name("mod-users").version("1.0.0");
+    var registry = new EcrArtifactRegistry().baseUrl(ECR_BASE_URL).namespace("folio");
+
+    when(ecrClient.describeImages(any(DescribeImagesRequest.class)))
+      .thenThrow(ImageNotFoundException.builder().message("Image not found").build());
+
+    assertThat(checker.exists(module, registry)).isFalse();
+    verify(log).warn("ECR image not found: folio/mod-users:1.0.0 (registryId: " + REGISTRY_ID + ")");
+  }
+
+  @Test
+  void exists_negative_repositoryNotFound() {
+    var module = new ModuleDefinition().name("mod-users").version("1.0.0");
+    var registry = new EcrArtifactRegistry().baseUrl(ECR_BASE_URL).namespace("folio");
+
+    when(ecrClient.describeImages(any(DescribeImagesRequest.class)))
+      .thenThrow(RepositoryNotFoundException.builder().message("Repository not found").build());
+
+    assertThat(checker.exists(module, registry)).isFalse();
+    verify(log).warn("ECR repository not found: folio/mod-users (registryId: " + REGISTRY_ID + ")");
+  }
+
+  @Test
+  void exists_negative_ecrException_throwsInfrastructureError() {
+    var module = new ModuleDefinition().name("mod-users").version("1.0.0");
+    var registry = new EcrArtifactRegistry().baseUrl(ECR_BASE_URL).namespace("folio");
+
+    var ecrException = (EcrException) EcrException.builder()
+      .statusCode(500)
+      .message("Internal server error")
+      .awsErrorDetails(AwsErrorDetails.builder().errorCode("InternalServerError").build())
+      .build();
+    when(ecrClient.describeImages(any(DescribeImagesRequest.class))).thenThrow(ecrException);
+
+    assertThatThrownBy(() -> checker.exists(module, registry))
+      .isInstanceOf(ApplicationGeneratorException.class)
+      .hasMessageContaining("ECR error 500 for folio/mod-users:1.0.0")
+      .satisfies(e -> assertThat(((ApplicationGeneratorException) e).getCategory())
+        .isEqualTo(ErrorCategory.INFRASTRUCTURE));
+  }
+
+  @Test
+  void exists_negative_blankBaseUrl_throwsConfigurationError() {
+    var module = new ModuleDefinition().name("mod-users").version("1.0.0");
+    var registry = new EcrArtifactRegistry().namespace("folio");
+
+    assertThatThrownBy(() -> checker.exists(module, registry))
+      .isInstanceOf(ApplicationGeneratorException.class)
+      .hasMessageContaining("ECR registry baseUrl is required")
+      .satisfies(e -> assertThat(((ApplicationGeneratorException) e).getCategory())
+        .isEqualTo(ErrorCategory.CONFIGURATION_ERROR));
+  }
+
+  @Test
+  void exists_negative_invalidBaseUrl_throwsConfigurationError() {
+    var module = new ModuleDefinition().name("mod-users").version("1.0.0");
+    var registry = new EcrArtifactRegistry().baseUrl("https://docker.io/v2").namespace("folio");
+
+    assertThatThrownBy(() -> checker.exists(module, registry))
+      .isInstanceOf(ApplicationGeneratorException.class)
+      .hasMessageContaining("Invalid ECR registry baseUrl")
+      .satisfies(e -> assertThat(((ApplicationGeneratorException) e).getCategory())
+        .isEqualTo(ErrorCategory.CONFIGURATION_ERROR));
+  }
+}

--- a/src/test/java/org/folio/app/generator/service/artifact/existence/FolioNpmArtifactExistenceCheckerTest.java
+++ b/src/test/java/org/folio/app/generator/service/artifact/existence/FolioNpmArtifactExistenceCheckerTest.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import org.apache.maven.plugin.logging.Log;
 import org.folio.app.generator.model.ModuleDefinition;
 import org.folio.app.generator.model.registry.artifact.FolioNpmArtifactRegistry;
-import org.folio.app.generator.model.types.ModuleType;
+import org.folio.app.generator.model.types.ArtifactRegistryType;
 import org.folio.app.generator.support.UnitTest;
 import org.folio.app.generator.utils.JsonConverter;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,8 +45,8 @@ class FolioNpmArtifactExistenceCheckerTest {
   }
 
   @Test
-  void getModuleType_positive() {
-    assertThat(checker.getModuleType()).isEqualTo(ModuleType.UI);
+  void getRegistryType_positive() {
+    assertThat(checker.getRegistryType()).isEqualTo(ArtifactRegistryType.FOLIO_NPM);
   }
 
   @Test

--- a/src/test/java/org/folio/app/generator/service/parsers/StringArtifactRegistryParserTest.java
+++ b/src/test/java/org/folio/app/generator/service/parsers/StringArtifactRegistryParserTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.folio.app.generator.model.registry.artifact.DockerHubArtifactRegistry;
+import org.folio.app.generator.model.registry.artifact.EcrArtifactRegistry;
 import org.folio.app.generator.model.registry.artifact.FolioNpmArtifactRegistry;
-import org.folio.app.generator.model.types.ArtifactRegistryType;
 import org.folio.app.generator.support.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,8 +21,8 @@ class StringArtifactRegistryParserTest {
   }
 
   @Test
-  void parseDocker_positive_namespaceOnly() {
-    var result = parser.parseDocker("folioorg");
+  void parse_positive_dockerHubNamespaceOnly() {
+    var result = parser.parse("docker-hub::folioorg");
 
     assertThat(result).isPresent();
     assertThat(result.get()).isInstanceOf(DockerHubArtifactRegistry.class);
@@ -31,8 +31,8 @@ class StringArtifactRegistryParserTest {
   }
 
   @Test
-  void parseDocker_positive_urlAndNamespace() {
-    var result = parser.parseDocker("https://custom-registry.io::custom-namespace");
+  void parse_positive_dockerHubBaseUrlAndNamespace() {
+    var result = parser.parse("docker-hub::https://custom-registry.io::custom-namespace");
 
     assertThat(result).isPresent();
     assertThat(result.get()).isInstanceOf(DockerHubArtifactRegistry.class);
@@ -41,37 +41,16 @@ class StringArtifactRegistryParserTest {
   }
 
   @Test
-  void parseDocker_positive_urlWithTrailingSlash() {
-    var result = parser.parseDocker("https://custom-registry.io/::namespace");
+  void parse_positive_dockerHubTrailingSlashRemoved() {
+    var result = parser.parse("docker-hub::https://custom-registry.io/::namespace");
 
     assertThat(result).isPresent();
     assertThat(result.get().getBaseUrl()).isEqualTo("https://custom-registry.io");
   }
 
   @Test
-  void parseDocker_positive_blankString() {
-    var result = parser.parseDocker("  ");
-
-    assertThat(result).isEmpty();
-  }
-
-  @Test
-  void parseDocker_positive_nullString() {
-    var result = parser.parseDocker(null);
-
-    assertThat(result).isEmpty();
-  }
-
-  @Test
-  void parseDocker_negative_invalidUrl() {
-    assertThatThrownBy(() -> parser.parseDocker("invalid-url::namespace"))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessageContaining("Invalid url provided");
-  }
-
-  @Test
-  void parseNpm_positive_namespaceOnly() {
-    var result = parser.parseNpm("npm-folio");
+  void parse_positive_folioNpmNamespaceOnly() {
+    var result = parser.parse("folio-npm::npm-folio");
 
     assertThat(result).isPresent();
     assertThat(result.get()).isInstanceOf(FolioNpmArtifactRegistry.class);
@@ -80,8 +59,8 @@ class StringArtifactRegistryParserTest {
   }
 
   @Test
-  void parseNpm_positive_urlAndNamespace() {
-    var result = parser.parseNpm("https://custom-npm.io::custom-repo");
+  void parse_positive_folioNpmBaseUrlAndNamespace() {
+    var result = parser.parse("folio-npm::https://custom-npm.io::custom-repo");
 
     assertThat(result).isPresent();
     assertThat(result.get()).isInstanceOf(FolioNpmArtifactRegistry.class);
@@ -90,48 +69,74 @@ class StringArtifactRegistryParserTest {
   }
 
   @Test
-  void parseNpm_positive_blankString() {
-    var result = parser.parseNpm("  ");
+  void parse_positive_ecrUrlOnly() {
+    var result = parser.parse("aws-ecr::https://123456789012.dkr.ecr.us-west-2.amazonaws.com");
 
+    assertThat(result).isPresent();
+    assertThat(result.get()).isInstanceOf(EcrArtifactRegistry.class);
+    assertThat(result.get().getBaseUrl()).isEqualTo("https://123456789012.dkr.ecr.us-west-2.amazonaws.com");
+    assertThat(result.get().getNamespace()).isNull();
+  }
+
+  @Test
+  void parse_positive_ecrUrlAndNamespace() {
+    var result = parser.parse("aws-ecr::https://123456789012.dkr.ecr.us-west-2.amazonaws.com::folio");
+
+    assertThat(result).isPresent();
+    assertThat(result.get()).isInstanceOf(EcrArtifactRegistry.class);
+    assertThat(result.get().getBaseUrl()).isEqualTo("https://123456789012.dkr.ecr.us-west-2.amazonaws.com");
+    assertThat(result.get().getNamespace()).isEqualTo("folio");
+  }
+
+  @Test
+  void parse_negative_blankString() {
+    var result = parser.parse("  ");
     assertThat(result).isEmpty();
   }
 
   @Test
-  void parseNpm_positive_nullString() {
-    var result = parser.parseNpm(null);
-
+  void parse_negative_nullString() {
+    var result = parser.parse(null);
     assertThat(result).isEmpty();
   }
 
   @Test
-  void parse_positive_dockerType() {
-    var result = parser.parse("test-namespace", ArtifactRegistryType.DOCKER_HUB);
-
-    assertThat(result).isPresent();
-    assertThat(result.get()).isInstanceOf(DockerHubArtifactRegistry.class);
-    assertThat(result.get().getNamespace()).isEqualTo("test-namespace");
+  void parse_negative_noPrefix() {
+    var result = parser.parse("folioorg");
+    assertThat(result).isEmpty();
   }
 
   @Test
-  void parse_positive_npmType() {
-    var result = parser.parse("test-repo", ArtifactRegistryType.FOLIO_NPM);
-
-    assertThat(result).isPresent();
-    assertThat(result.get()).isInstanceOf(FolioNpmArtifactRegistry.class);
-    assertThat(result.get().getNamespace()).isEqualTo("test-repo");
+  void parse_negative_unknownPrefix() {
+    var result = parser.parse("github::folio-org");
+    assertThat(result).isEmpty();
   }
 
   @Test
-  void parseDocker_positive_trimmedValue() {
-    var result = parser.parseDocker("  folioorg  ");
+  void parse_negative_dockerHubInvalidUrl() {
+    assertThatThrownBy(() -> parser.parse("docker-hub::invalid-url::namespace"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Invalid url provided");
+  }
+
+  @Test
+  void parse_negative_ecrInvalidUrl() {
+    assertThatThrownBy(() -> parser.parse("aws-ecr::invalid-url"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Invalid url provided");
+  }
+
+  @Test
+  void parse_positive_dockerHubTrimmedNamespace() {
+    var result = parser.parse("docker-hub::  folioorg  ");
 
     assertThat(result).isPresent();
     assertThat(result.get().getNamespace()).isEqualTo("folioorg");
   }
 
   @Test
-  void parseNpm_positive_trimmedValue() {
-    var result = parser.parseNpm("  npm-folio  ");
+  void parse_positive_folioNpmTrimmedNamespace() {
+    var result = parser.parse("folio-npm::  npm-folio  ");
 
     assertThat(result).isPresent();
     assertThat(result.get().getNamespace()).isEqualTo("npm-folio");

--- a/src/test/java/org/folio/app/generator/service/parsers/StringArtifactRegistryParserTest.java
+++ b/src/test/java/org/folio/app/generator/service/parsers/StringArtifactRegistryParserTest.java
@@ -9,6 +9,9 @@ import org.folio.app.generator.model.registry.artifact.FolioNpmArtifactRegistry;
 import org.folio.app.generator.support.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @UnitTest
 class StringArtifactRegistryParserTest {
@@ -88,28 +91,11 @@ class StringArtifactRegistryParserTest {
     assertThat(result.get().getNamespace()).isEqualTo("folio");
   }
 
-  @Test
-  void parse_negative_blankString() {
-    var result = parser.parse("  ");
-    assertThat(result).isEmpty();
-  }
-
-  @Test
-  void parse_negative_nullString() {
-    var result = parser.parse(null);
-    assertThat(result).isEmpty();
-  }
-
-  @Test
-  void parse_negative_noPrefix() {
-    var result = parser.parse("folioorg");
-    assertThat(result).isEmpty();
-  }
-
-  @Test
-  void parse_negative_unknownPrefix() {
-    var result = parser.parse("github::folio-org");
-    assertThat(result).isEmpty();
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"  ", "folioorg", "github::folio-org"})
+  void parse_negative_returnsEmpty(String input) {
+    assertThat(parser.parse(input)).isEmpty();
   }
 
   @Test

--- a/src/test/java/org/folio/app/generator/utils/JsonConverterTest.java
+++ b/src/test/java/org/folio/app/generator/utils/JsonConverterTest.java
@@ -6,12 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import lombok.SneakyThrows;
 import org.folio.app.generator.configuration.SpringConfiguration;
 import org.folio.app.generator.model.ApplicationDescriptor;
 import org.folio.app.generator.model.ApplicationDescriptorTemplate;
 import org.folio.app.generator.support.UnitTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 @UnitTest
 class JsonConverterTest {
@@ -40,5 +42,30 @@ class JsonConverterTest {
 
     assertNotNull(applicationDescriptor);
     assertThat(applicationDescriptor.getId()).isEqualTo("app-consortia-1.0.0-SNAPSHOT");
+  }
+
+  @Test
+  @SneakyThrows
+  void writeValue_positive_outputIsPrettyPrinted(@TempDir Path tempDir) {
+    var target = tempDir.resolve("output.json").toFile();
+    var payload = Map.of("name", "app-test", "version", "1.0.0");
+
+    jsonConverter.writeValue(target, payload);
+
+    var written = Files.readString(target.toPath(), StandardCharsets.UTF_8);
+    assertThat(written).contains("\n");
+    assertThat(written).contains("  ");
+    assertThat(written).contains("\"name\"");
+    assertThat(written).contains("\"version\"");
+  }
+
+  @Test
+  @SneakyThrows
+  void toJsonString_positive_outputIsCompact() {
+    var payload = Map.of("name", "app-test", "version", "1.0.0");
+
+    var json = jsonConverter.toJsonString(payload);
+
+    assertThat(json).doesNotContain("\n");
   }
 }

--- a/src/test/java/org/folio/app/generator/utils/JsonConverterTest.java
+++ b/src/test/java/org/folio/app/generator/utils/JsonConverterTest.java
@@ -53,10 +53,7 @@ class JsonConverterTest {
     jsonConverter.writeValue(target, payload);
 
     var written = Files.readString(target.toPath(), StandardCharsets.UTF_8);
-    assertThat(written).contains("\n");
-    assertThat(written).contains("  ");
-    assertThat(written).contains("\"name\"");
-    assertThat(written).contains("\"version\"");
+    assertThat(written).contains("\n", "  ", "\"name\"", "\"version\"");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Implements [APPDESCRIP-71](https://folio-org.atlassian.net/browse/APPDESCRIP-71) — Workstream 4 of the [Custom & Optional Applications in CI/CD Pipelines](https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/1781727233) design.

Adds AWS ECR as a supported artifact registry type and introduces a `validateFallbackArtifacts` flag so builds that include custom feature-branch modules (whose artifacts live outside the configured registries) don't fail the validation step.

## Changes

### 1. AWS ECR artifact registry

- New `AWS_ECR` value in `ArtifactRegistryType` enum.
- New `EcrArtifactRegistry` model — `baseUrl` = ECR endpoint (`https://<account>.dkr.ecr.<region>.amazonaws.com`), optional `namespace` prefix.
- New `EcrArtifactExistenceChecker` — uses AWS SDK `EcrClient.describeImages(...)`; classifies `ImageNotFoundException` / `RepositoryNotFoundException` as legitimate "not found", other `EcrException` as `INFRASTRUCTURE` errors.
- New `EcrCondition` + `ecrClient` Spring bean, registered when `validateArtifacts=true`. Authenticates via the same `DefaultCredentialsProvider` chain already used by the S3 client (env vars, `~/.aws/credentials`, EC2/ECS instance profile, OIDC).
- New `software.amazon.awssdk:ecr` dependency in `pom.xml`.

### 2. Refactor: dispatch by `ArtifactRegistryType`

`ArtifactExistenceCheckerFacade` previously keyed checkers by `ModuleType`. With ECR added, two checkers (DockerHub + ECR) now serve `ModuleType.BE`, which would collide in the `toMap` collector. Interface changed:

```java
// before
ModuleType getModuleType();
// after
ArtifactRegistryType getRegistryType();
```

Facade now dispatches on `registry.getType()`; the redundant `type` parameter dropped from `exists(...)`.

### 3. CLI grammar for artifact registries (**breaking change**)

Aligned the artifact-registry CLI syntax with the descriptor-side grammar (`okapi::`, `s3::`, `simple::`). Every entry now requires a type prefix — `docker-hub::`, `aws-ecr::`, or `folio-npm::`. The old bare-namespace format (`-DbeArtifactRegistries="folioorg"`) is no longer accepted.

**Migration:**

| Before | After |
| --- | --- |
| `-DbeArtifactRegistries="folioorg"` | `-DbeArtifactRegistries="docker-hub::folioorg"` |
| `-DbeArtifactRegistries="https://private.io/v2::my-ns"` | `-DbeArtifactRegistries="docker-hub::https://private.io/v2::my-ns"` |
| `-DuiArtifactRegistries="npm-folio"` | `-DuiArtifactRegistries="folio-npm::npm-folio"` |

**Motivation:** ECR is a third BE-side type. Without prefixes, `-DbeArtifactRegistries` couldn't accept a mix of DockerHub and ECR entries in the same list — the flag was type-locked to DockerHub. Prefixes let one flag accept any allowed type and enable mixing:

```
-DbeArtifactRegistries="docker-hub::folioorg,aws-ecr::https://123.dkr.ecr.us-west-2.amazonaws.com::folio"
```

Category-level validation preserved: `beArtifactRegistries` accepts `docker-hub::` + `aws-ecr::`; `uiArtifactRegistries` accepts `folio-npm::`; `artifactRegistries` accepts all three. Wrong-category entries fail-fast with `IllegalArgumentException`.

`StringArtifactRegistryParser` rewritten as pattern-driven, mirroring `StringModuleRegistryParser`. `ArtifactRegistryProvider` collapsed five near-identical per-category methods into one generic `processCategory(cmd, xml, allowedTypes)`.

### 4. `validateFallbackArtifacts` flag

New Mojo parameter (default `true`) to skip artifact validation for modules resolved from fallback descriptor registries — targets custom UI modules referenced via npm git refs and BE modules whose images live outside the configured registries.

| `validateArtifacts` | `validateFallbackArtifacts` | Behavior |
| --- | --- | --- |
| `false` | (ignored) | Nothing validated (unchanged). |
| `true` | `true` (default) | Every candidate validated — primary and fallback (unchanged). |
| `true` | `false` | Primary validated; fallback-resolved modules skip artifact check. |

Wiring:
- `ModuleRegistry.isFallback()` / `setFallback(boolean)` added to the interface + `boolean fallback` field on Okapi/S3/Simple impls.
- `ModuleRegistryProvider.processFallbackRegistries(...)` now stamps `setFallback(true)` on every merged fallback-list entry.
- `ModuleVersionService.getMatchingVersionFromRegistry(...)` extended validation gate: `if (!validateArtifacts || (registry.isFallback() && !validateFallbackArtifacts))` short-circuits the artifact-existence loop.

### 5. Pretty-printed JSON file output

`JsonConverter.writeValue(File, Object)` now uses `writerWithDefaultPrettyPrinter()`. Application descriptors, `update-result.json`, and `execution-result.json` are written multi-line with 2-space indentation. Scope: file output only — `toJsonString(...)` and JSON sent to remote APIs (e.g., mgr-applications) stay compact.